### PR TITLE
chore(deps): add humantime as v0.5 wiring placeholder + dogfood demo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,7 @@ dependencies = [
  "clap",
  "criterion",
  "directories",
+ "humantime",
  "owo-colors",
  "proptest",
  "serde",
@@ -444,6 +445,12 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "humantime"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "icu_collections"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ anyhow = "1"
 thiserror = "2"
 ureq = { version = "2", features = ["json"] }
 strsim = "0.11"
+humantime = "2"
 owo-colors = { version = "4", features = ["supports-colors"] }
 supports-color = "3"
 directories = "6"


### PR DESCRIPTION
This is the first dogfood test of the SBOM-diff Action wired up in
60e772d. If everything works end-to-end, a bomdrift comment should
appear on this PR within ~30s of opening, showing `humantime@2.3.0`
as an Added component.

## What this PR does

- Adds `humantime = "2"` to `[dependencies]`. Currently unused; the
  intent is to humanize the maintainer-age enricher's "X days ago"
  formatting in v0.5.
- Refreshes `Cargo.lock` to pin `humantime@2.3.0`.

## What we're testing

1. Action triggers on a `Cargo.toml`-touching PR. ✓ (you're seeing this)
2. `anchore/sbom-action@v0` generates a CycloneDX SBOM from the Rust
   manifest at the PR head + the base ref.
3. `Metbcy/bomdrift@v1` downloads the v0.4.2 release archive,
   cosign-verifies it, runs `bomdrift diff before.json after.json`,
   and posts the rendered markdown as a PR comment marked
   `<!-- bomdrift:diff -->`.
4. The comment correctly identifies `humantime@2.3.0` as an Added
   component and surfaces no other (false-positive) signals.

## Disposition

If the comment lands cleanly:
- merge this and let `humantime` sit as a no-op until v0.5 wires it, OR
- revert with a "demo successful, reverting" follow-up. Either way,
  the dogfood proof exists in the PR's comment history.

If the comment fails or shows wrong content, that's a bug in the
action / SBOM generator / bomdrift itself — investigate and fix
before merging.