### PR TITLE
feat(action): v0.5 zero-config invocation (Phase B)

### DIFF
--- a/.github/workflows/sbom-diff.yml
+++ b/.github/workflows/sbom-diff.yml
@@ -1,15 +1,24 @@
 name: SBOM diff
 
 # Eat-your-own-dogfood: every PR that touches the Rust dependency
-# manifest gets a bomdrift comment showing the supply-chain diff between
-# main and the PR head. Proves the action works end-to-end on real
-# changes, and gives prospective users a live PR comment as a demo.
+# manifest (or the action surface itself) gets a bomdrift comment
+# showing the supply-chain diff between main and the PR head.
+#
+# `uses: ./` runs the action code from THIS PR, not the published
+# release — so a regression in action.yml / entrypoint.sh shows up
+# on the same PR that introduced it. The actions/checkout step is
+# only here to give `./` something to point at; consumers who copy
+# this workflow as `uses: Metbcy/bomdrift@v1` don't need the
+# checkout step (the v0.5 zero-config flow handles the before/after
+# checkouts internally).
 
 on:
   pull_request:
     paths:
       - Cargo.toml
       - Cargo.lock
+      - action.yml
+      - entrypoint.sh
       - .github/workflows/sbom-diff.yml
 
 permissions:
@@ -24,48 +33,14 @@ jobs:
   diff:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout PR head
+      - name: Checkout PR head (so `uses: ./` resolves)
         uses: actions/checkout@v4
 
-      - name: Generate "after" SBOM (PR head)
-        uses: anchore/sbom-action@v0
+      - name: Run bomdrift (zero-config)
+        uses: ./
         with:
-          path: .
-          format: cyclonedx-json
-          output-file: after.json
-        # NOTE: Syft's default cataloger set on `dir:.` includes the
-        # file-level cataloger, which emits each YAML workflow + lockfile
-        # as a `file:`-ecosystem component. Path differs between PR-head
-        # and base-ref checkouts (`./base/...`), so those produce phantom
-        # add/remove pairs in the diff. Two attempts to filter via
-        # SYFT_DEFAULT_CATALOGERS (`-file` and `directory,-file`) didn't
-        # work — Syft seemed to ignore the env var or parse only the
-        # first token. Tracked as a v0.5 follow-up: either filter
-        # `Ecosystem::Other("file")` in the bomdrift parser, or document
-        # a `.syft.yaml` config-file approach in the Action chapter.
-
-      # Sibling checkout of the base ref so the SBOM generator sees a
-      # clean snapshot of main without the PR's diff applied.
-      - name: Checkout base ref
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.base.ref }}
-          path: base
-
-      - name: Generate "before" SBOM (base ref)
-        uses: anchore/sbom-action@v0
-        with:
-          path: ./base
-          format: cyclonedx-json
-          output-file: before.json
-
-      - name: Run bomdrift
-        uses: Metbcy/bomdrift@v1
-        with:
-          before-sbom: before.json
-          after-sbom:  after.json
           # Informational only on the bomdrift repo; if the action ever
           # surfaces something dangerous on a bomdrift PR, that's
           # signal — not a merge-block. Tighten to `critical-cve` once
           # we have enough false-positive history to know what's noise.
-          fail-on:     none
+          fail-on: none

--- a/.github/workflows/sbom-diff.yml
+++ b/.github/workflows/sbom-diff.yml
@@ -33,7 +33,12 @@ jobs:
   diff:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout PR head (so `uses: ./` resolves)
+      - name: Checkout PR head
+        # The `uses: ./` step below resolves the local action against the
+        # checked-out tree; this checkout step exists only to give it
+        # something to point at. Consumers copying this workflow as
+        # `uses: Metbcy/bomdrift@v1` don't need the checkout step (the
+        # v0.5 zero-config flow handles before/after checkouts internally).
         uses: actions/checkout@v4
 
       - name: Run bomdrift (zero-config)

--- a/action.yml
+++ b/action.yml
@@ -5,12 +5,53 @@ branding:
   color: blue
 
 inputs:
+  # ---- Zero-config inputs (v0.5+) -------------------------------------------
+  #
+  # Defaults populate from the `pull_request` event payload. On other event
+  # types (push, workflow_dispatch, schedule), supply both refs explicitly
+  # OR fall back to the deprecated `before-sbom`/`after-sbom` inputs.
+
+  before-ref:
+    description: |
+      Git ref / SHA to check out as the "before" side of the diff. On a
+      `pull_request` event, defaults to the PR's base branch. Required
+      when the action runs on any other event AND `before-sbom` is unset.
+    default: ${{ github.event.pull_request.base.ref }}
+  after-ref:
+    description: |
+      Git ref / SHA to check out as the "after" side. On a `pull_request`
+      event, defaults to the PR head SHA. Required when the action runs
+      on any other event AND `after-sbom` is unset.
+    default: ${{ github.event.pull_request.head.sha }}
+  path:
+    description: |
+      Subdirectory of the checked-out ref to scan with Syft. Defaults to
+      the repository root. Useful for monorepos where dependencies live
+      under a workspace path (e.g. `path: services/api`).
+    default: '.'
+
+  # ---- Explicit-SBOM inputs (v0.4-compat, deprecated) -----------------------
+  #
+  # When set, bypass the in-action SBOM generation entirely and use the
+  # supplied paths directly. v0.4 callers continue to work unchanged. New
+  # callers should prefer the zero-config flow above; these inputs remain
+  # documented as the "I generate SBOMs in a non-Syft toolchain" escape
+  # hatch and won't be removed in the v1 lifetime.
+
   before-sbom:
-    description: Path to the "before" SBOM (CycloneDX, SPDX, or Syft JSON).
-    required: true
+    description: |
+      Path to the "before" SBOM (CycloneDX, SPDX, or Syft JSON). When set,
+      bypasses the v0.5 zero-config Syft invocation. Optional in v0.5+
+      (was required in v0.4); leaving it empty triggers the in-action
+      SBOM generation against `before-ref`.
+    default: ''
   after-sbom:
-    description: Path to the "after" SBOM (CycloneDX, SPDX, or Syft JSON).
-    required: true
+    description: |
+      Path to the "after" SBOM. Same migration story as `before-sbom`.
+    default: ''
+
+  # ---- Behavior knobs (unchanged) -------------------------------------------
+
   format:
     description: Force input format detection (auto|cdx|spdx|syft).
     default: auto
@@ -64,15 +105,55 @@ inputs:
 runs:
   using: composite
   steps:
+    # Two sibling checkouts at fixed paths under $GITHUB_WORKSPACE. The
+    # path: parameter is required to be a relative subpath of the workspace
+    # by actions/checkout, so we use opaque names (`__bomdrift_before`,
+    # `__bomdrift_after`) that won't collide with consumer paths. Both
+    # steps are skipped when the corresponding `*-sbom` input is set, so
+    # v0.4 advanced consumers (BYO SBOMs) pay neither the network round-trip
+    # nor the disk usage.
+
+    - name: Checkout after-ref (PR head, default)
+      if: inputs.after-sbom == ''
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.after-ref }}
+        path: __bomdrift_after
+        fetch-depth: 1
+        persist-credentials: false
+
+    - name: Checkout before-ref (PR base, default)
+      if: inputs.before-sbom == ''
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.before-ref }}
+        path: __bomdrift_before
+        fetch-depth: 1
+        persist-credentials: false
+
+    # Syft is only installed when at least one side needs in-action SBOM
+    # generation. anchore/sbom-action's published `download-syft` sub-action
+    # handles arch detection + tool-cache reuse — re-implementing it inline
+    # would lose those for no real gain.
+    - name: Install Syft (for in-action SBOM generation)
+      if: inputs.before-sbom == '' || inputs.after-sbom == ''
+      uses: anchore/sbom-action/download-syft@v0
+
     - name: Install cosign (for release signature verification)
       if: inputs.verify-signatures == 'true'
       uses: sigstore/cosign-installer@v3
+
     - name: Run bomdrift
       shell: bash
       run: ${{ github.action_path }}/entrypoint.sh
       env:
         BEFORE_SBOM: ${{ inputs.before-sbom }}
         AFTER_SBOM: ${{ inputs.after-sbom }}
+        BEFORE_REF: ${{ inputs.before-ref }}
+        AFTER_REF: ${{ inputs.after-ref }}
+        BOMDRIFT_PATH: ${{ inputs.path }}
+        BEFORE_CHECKOUT_DIR: ${{ github.workspace }}/__bomdrift_before
+        AFTER_CHECKOUT_DIR: ${{ github.workspace }}/__bomdrift_after
         INPUT_FORMAT: ${{ inputs.format }}
         OUTPUT_FORMAT: ${{ inputs.output }}
         COMMENT_ON_PR: ${{ inputs.comment-on-pr }}

--- a/docs/src/github-action.md
+++ b/docs/src/github-action.md
@@ -4,12 +4,43 @@ The `Metbcy/bomdrift` action is a **composite action** (no Docker), which
 keeps PR-comment latency low — typically 5–10s on a warm runner versus
 30s+ for a Docker container action.
 
+## Quick start (zero-config, v0.5+)
+
+On a `pull_request` workflow, the action defaults to comparing the PR's
+base branch against the PR's head SHA — no checkout step, no Syft step,
+no SBOM-path wiring needed:
+
+```yaml
+on: pull_request
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  diff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Metbcy/bomdrift@v1
+```
+
+That's it. The action checks out both refs into opaque sibling paths,
+generates CycloneDX-JSON SBOMs via Syft (installed automatically and
+cached across job runs), and posts the rendered diff as an upserted PR
+comment.
+
+If you already produce SBOMs through a non-Syft toolchain — Trivy,
+SPDX-tools, an in-house generator — supply the file paths via the
+`before-sbom` / `after-sbom` inputs instead. The advanced flow below
+documents that path; both flows continue to be supported in v1.
+
 ## Inputs
 
 | Input | Required | Default | Description |
 |---|---|---|---|
-| `before-sbom` | yes | — | Path to the "before" SBOM (CycloneDX, SPDX, or Syft JSON). |
-| `after-sbom`  | yes | — | Path to the "after" SBOM. |
+| `before-ref` | no | `${{ github.event.pull_request.base.ref }}` | Git ref / SHA to check out as the "before" side. The default works on `pull_request` events; supply explicitly on other events. Ignored when `before-sbom` is set. |
+| `after-ref`  | no | `${{ github.event.pull_request.head.sha }}`  | Git ref / SHA for the "after" side. Same defaulting story. Ignored when `after-sbom` is set. |
+| `path`       | no | `.` | Subdirectory of the checked-out ref to scan with Syft. Useful for monorepos (`path: services/api`). Ignored when both `*-sbom` inputs are set. |
+| `before-sbom` | no | `` (empty) | Path to the "before" SBOM (CycloneDX, SPDX, or Syft JSON). When set, bypasses the v0.5 zero-config Syft invocation and uses this file directly. The escape hatch for non-Syft toolchains. |
+| `after-sbom`  | no | `` (empty) | Path to the "after" SBOM. Same migration story as `before-sbom`. |
 | `format`      | no  | `auto` | Force input format detection: `auto`/`cdx`/`spdx`/`syft`. |
 | `output`      | no  | `markdown` | Output format: `terminal`/`markdown`/`json`/`sarif`. The PR-comment path requires `markdown`. |
 | `comment-on-pr` | no | `true` | Post the rendered diff as a PR comment when the workflow runs on a `pull_request` event. Set to `false` for diff-only / report-only workflows. |
@@ -38,10 +69,12 @@ The action does not declare formal outputs. Its side effects are:
 
 ## Common patterns
 
-### Generate the SBOMs in the same workflow
+### Bring your own SBOMs (advanced / pre-v0.5 flow)
 
-The most common pattern: generate before and after SBOMs from the base ref
-and the PR head, respectively, then feed both into bomdrift.
+When the SBOMs come from a non-Syft toolchain (Trivy, SPDX-tools,
+proprietary scanners) or you already generate them in an earlier job
+step, supply both paths explicitly. The action skips the in-action
+Syft invocation entirely:
 
 ```yaml
 - uses: actions/checkout@v4
@@ -54,6 +87,12 @@ and the PR head, respectively, then feed both into bomdrift.
 - uses: Metbcy/bomdrift@v1
   with: { before-sbom: before.json, after-sbom: after.json }
 ```
+
+This is the v0.4-era "manual" pattern. It still works in v0.5 — the
+`before-sbom` / `after-sbom` inputs were `required: true` in v0.4 and
+became `required: false` in v0.5; nothing else changed about how they
+behave. Existing v0.4 workflows continue to function unchanged after a
+`@v1` tag bump.
 
 ### Block the merge on critical findings
 
@@ -135,5 +174,29 @@ default). Without it, the comment-upsert step fails with a 403; the
 action's exit code remains the bomdrift exit (so a `fail-on` trip still
 fails the workflow correctly).
 
-`contents: read` is required for the SBOM-checkout step, not the action
-itself. The action only reads files passed via `before-sbom` / `after-sbom`.
+`contents: read` is required so the action's internal `actions/checkout`
+steps (zero-config flow) can fetch both refs. In the bring-your-own-SBOMs
+flow it's still required by whichever step generates the SBOMs upstream.
+
+## What the action does (v0.5+)
+
+When the zero-config flow runs (no explicit `before-sbom` / `after-sbom`):
+
+1. **Two sibling checkouts** of `before-ref` and `after-ref` into
+   `${{ github.workspace }}/__bomdrift_before` and `__bomdrift_after`.
+   Both with `fetch-depth: 1` and `persist-credentials: false`. Skipped
+   for whichever side has a pre-supplied SBOM path.
+2. **Syft installed** via `anchore/sbom-action/download-syft@v0`. Cached
+   across job runs in the runner's tool cache.
+3. **`syft scan dir:...` against each checkout's `${path}` subtree**,
+   producing CycloneDX-JSON into a tempfile under `$RUNNER_TEMP`. The
+   bomdrift parser drops `Ecosystem::Other("file")` pseudo-components
+   that Syft's directory cataloger emits — set
+   `--include-file-components` (CLI) or pass a pre-generated SBOM via
+   `before-sbom` / `after-sbom` to bypass.
+4. **`bomdrift diff` runs** as in the v0.4 flow, and the upsert + step
+   summary plumbing is unchanged.
+
+The new behavior costs about 30 MB of one-time tool cache and 3–5s of
+cold-cache wall time per first invocation. Subsequent runs in the same
+job (or in repos that share the runner's tool cache) reuse Syft.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -179,6 +179,51 @@ download_bomdrift() {
   printf '%s' "$bin"
 }
 
+# ---- Generate an SBOM for one side of the diff -------------------------------
+#
+# Used in the v0.5 zero-config flow when the consumer didn't supply a
+# pre-computed `before-sbom` / `after-sbom`. The action's composite step
+# already checked out the requested ref into `${checkout_dir}` and installed
+# Syft into PATH; this function just runs the scan.
+#
+# Args:
+#   $1 — checkout directory (absolute path, e.g. ${GITHUB_WORKSPACE}/__bomdrift_after)
+#   $2 — project subdirectory within the checkout (default ".")
+#   $3 — output SBOM path (CycloneDX JSON)
+
+generate_sbom() {
+  local checkout_dir="$1"
+  local subpath="${2:-.}"
+  local out="$3"
+
+  if [ ! -d "$checkout_dir" ]; then
+    fail "checkout directory missing: ${checkout_dir} (the in-action checkout step likely failed; check the job log for actions/checkout errors)"
+  fi
+  # Trim a trailing slash, then trim leading "./" so users who write `path: ./`
+  # or `path: services/api/` get the canonical path Syft expects.
+  local clean="${subpath%/}"
+  clean="${clean#./}"
+  if [ -z "$clean" ]; then
+    clean="."
+  fi
+  local source_dir="${checkout_dir}/${clean}"
+  if [ ! -d "$source_dir" ]; then
+    fail "scan path not found: ${source_dir} (resolved from input path='${subpath}')"
+  fi
+
+  if ! command -v syft >/dev/null 2>&1; then
+    fail "syft not installed; the action's Syft-install step should have run before this point"
+  fi
+
+  log "Generating SBOM for ${source_dir}"
+  # `dir:` source pins Syft to directory cataloging (no container or git
+  # plumbing). CycloneDX-JSON because bomdrift's CDX parser is the most
+  # battle-tested code path; SPDX/Syft-native are also accepted but have
+  # less coverage in our real-world corpus.
+  syft scan "dir:${source_dir}" -o "cyclonedx-json=${out}" --quiet
+  endlog
+}
+
 # ---- Run bomdrift diff -------------------------------------------------------
 
 run_diff() {
@@ -210,6 +255,11 @@ run_diff() {
 main() {
   local before="${BEFORE_SBOM:-}"
   local after="${AFTER_SBOM:-}"
+  local before_ref="${BEFORE_REF:-}"
+  local after_ref="${AFTER_REF:-}"
+  local before_checkout="${BEFORE_CHECKOUT_DIR:-}"
+  local after_checkout="${AFTER_CHECKOUT_DIR:-}"
+  local scan_path="${BOMDRIFT_PATH:-.}"
   local input_format="${INPUT_FORMAT:-auto}"
   local output_format="${OUTPUT_FORMAT:-markdown}"
   local comment_on_pr="${COMMENT_ON_PR:-true}"
@@ -217,11 +267,42 @@ main() {
   local fail_on="${FAIL_ON:-none}"
   local baseline="${BASELINE:-}"
 
-  if [ -z "$before" ] || [ -z "$after" ]; then
-    fail "before-sbom and after-sbom inputs are required"
+  # ---- Resolve "before" SBOM path -------------------------------------------
+  #
+  # Three modes, in priority order:
+  #   1. BEFORE_SBOM is set — explicit-SBOM (v0.4-compat / advanced) flow.
+  #      Validate the path exists; never re-generate.
+  #   2. BEFORE_SBOM is unset AND a checkout dir exists — zero-config flow.
+  #      Generate via Syft into a tempfile.
+  #   3. Neither — fail loudly with migration guidance.
+
+  if [ -z "$before" ]; then
+    if [ -z "$before_ref" ]; then
+      fail "before-ref is empty and before-sbom is unset. On non-pull_request events the default is empty; supply before-ref explicitly OR provide before-sbom."
+    fi
+    if [ -z "$before_checkout" ] || [ ! -d "$before_checkout" ]; then
+      fail "in-action checkout of '${before_ref}' produced no directory at '${before_checkout}'. Check the actions/checkout step in the job log."
+    fi
+    # GNU and BSD `mktemp` disagree on `--suffix`, and macOS-hosted runners
+    # ship the BSD form. A predictable filename under $RUNNER_TEMP (always
+    # set on GitHub-hosted runners; falls back to /tmp elsewhere) avoids
+    # the portability cliff.
+    before="${RUNNER_TEMP:-/tmp}/bomdrift_before.cdx.json"
+    generate_sbom "$before_checkout" "$scan_path" "$before"
   fi
   if [ ! -f "$before" ]; then
     fail "before-sbom not found: $before"
+  fi
+
+  if [ -z "$after" ]; then
+    if [ -z "$after_ref" ]; then
+      fail "after-ref is empty and after-sbom is unset. Supply after-ref explicitly OR provide after-sbom."
+    fi
+    if [ -z "$after_checkout" ] || [ ! -d "$after_checkout" ]; then
+      fail "in-action checkout of '${after_ref}' produced no directory at '${after_checkout}'. Check the actions/checkout step in the job log."
+    fi
+    after="${RUNNER_TEMP:-/tmp}/bomdrift_after.cdx.json"
+    generate_sbom "$after_checkout" "$scan_path" "$after"
   fi
   if [ ! -f "$after" ]; then
     fail "after-sbom not found: $after"


### PR DESCRIPTION
## Summary

Phase B of the v0.5 OSS-adoption milestone (`~/.claude/plans/bomdrift-v0.5-adoption.md`).

Bakes Syft and the before/after checkouts INTO the action so consumers can call `uses: Metbcy/bomdrift@v1` with no surrounding YAML on a `pull_request` trigger and get a clean comment back.

- New optional inputs: `before-ref`, `after-ref`, `path` (smart pull_request defaults)
- `before-sbom` / `after-sbom` go from required to optional (v0.4 advanced flow stays supported, deprecated)
- Action.yml gains two `actions/checkout@v4` steps + `anchore/sbom-action/download-syft@v0` install — gated on the explicit-SBOM inputs being unset
- Dogfood workflow collapses from ~50 lines to ~15 and switches to `uses: ./` so the PR self-tests the action code
- Docs lead with the 5-line zero-config snippet; advanced flow renamed to "Bring your own SBOMs"

## Test plan

- [x] `cargo test --release` — 259 tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `bash examples/run-all.sh` — all 4 scenarios pass
- [ ] **CI on this PR**: the dogfood SBOM-diff workflow uses `uses: ./` to invoke the new action code. A successful run with a clean PR comment validates the zero-config flow end-to-end.

## Pinned decisions

- `SYFT_CATALOGERS=directory,-file` env var deliberately not set — Phase A's parser-level `filter_file_components` handles file-noise comprehensively, and the previous agent's three workflow-side attempts (8530d67, 12fdfe9, 9800769) showed Syft ignores or mis-parses the env var. Belt-and-suspenders here would only re-introduce the known-flaky surface.
- `actions/checkout` `path:` lands in `__bomdrift_before` / `__bomdrift_after` under `\$GITHUB_WORKSPACE` (required by the action's `path:` contract). Opaque names so they don't collide with consumer paths in advanced setups.
- Tempfiles use `\$RUNNER_TEMP` rather than `mktemp --suffix=` since macOS runners ship BSD mktemp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)