### PR TITLE
feat(render): v0.5 collapsible PR comment + severity-sort + footer (Phase C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,42 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   who want the raw cataloger output (debugging, auditing). Off by
   default; enabling it restores the pre-v0.5 behavior.
 
+- **Markdown comment is now collapsible.** Each per-category section
+  (Added / Removed / Version changed / Vulnerabilities / Possible
+  typosquats / Multi-major version jumps / Young maintainers /
+  License changed) is wrapped in a `<details><summary>` block. The
+  `### Section (count)` header stays visible above the wrapper so
+  the table of contents still works; the body is hidden by default
+  for skim-readability on big diffs. Reviewers expand the sections
+  they care about.
+
+- **Severity-sorted vulnerability rows.** Within the Vulnerabilities
+  section, components are ordered by their highest-severity
+  advisory (Critical first, then High / Medium / Low / None), with
+  alphabetical tie-breaking on ecosystem+name. Per-component
+  advisories continue to be severity-then-id sorted as before.
+  Critical / High findings now cluster at the top of the table —
+  the load-bearing rows that justify a reviewer's attention.
+
+- **`<summary>` teasers** on the Vulnerabilities and Possible
+  typosquats sections surface the most-actionable item without
+  expanding (e.g. `top severity: CRITICAL (CVE-2025-foo)` or
+  `top similarity: 0.95 (axiosx → axios)`).
+
+- **Per-section "Why this matters" links** in the markdown output,
+  reusing the SARIF rule helpUris that v0.4.2 introduced. Reviewers
+  click through to the docs chapter explaining what the enricher is
+  detecting and why.
+
+- **`--repo-url` flag** (also reads `BOMDRIFT_REPO_URL` env var) on
+  `bomdrift diff`. When set, the markdown comment renders an
+  action-affordance footer with three links: a pre-filled "Report
+  this finding" issue URL, the `/bomdrift suppress <id>`
+  suppress-comment hint (Phase D wires the actual mechanism), and
+  the docs site. When unset, the footer is omitted entirely so
+  forks / standalone CLI use don't render dead links to bomdrift's
+  own issue tracker.
+
 ## [0.4.4] - 2026-04-28
 
 The "make the action actually produce output" patch release. Sister

--- a/examples/axios-incident/expected-output.md
+++ b/examples/axios-incident/expected-output.md
@@ -8,29 +8,45 @@
 | License changed | 0 |
 | Possible typosquats | 1 |
 
-### Added
+### Added (1)
+
+<details><summary>Show details</summary>
 
 | Ecosystem | Name | Version |
 |---|---|---|
 | npm | plain-crypto-js | 4.2.1 |
 
-### Removed
+</details>
+
+### Removed (1)
+
+<details><summary>Show details</summary>
 
 | Ecosystem | Name | Version |
 |---|---|---|
 | library | no-purl-component | 0.1.0 |
 
-### Version changed
+</details>
+
+### Version changed (1)
+
+<details><summary>Show details</summary>
 
 | Ecosystem | Name | Before | After |
 |---|---|---|---|
 | npm | axios | 1.14.0 | 1.14.1 |
 
-### Possible typosquats
+</details>
 
-These newly added dependencies have names similar to popular packages. High similarity does not prove malicious intent — investigate the package source before merging.
+### Possible typosquats (1)
+
+<details><summary>Show details · top similarity: 0.95 (plain-crypto-js → crypto-js)</summary>
+
+These newly added dependencies have names similar to popular packages. High similarity does not prove malicious intent — investigate the package source before merging. [Why this matters](https://metbcy.github.io/bomdrift/enrichers/typosquat.html)
 
 | Ecosystem | Name | Version | Similar to | Similarity |
 |---|---|---|---|---:|
 | npm | plain-crypto-js | 4.2.1 | crypto-js | 0.95 |
+
+</details>
 

--- a/examples/baseline-suppression/expected-output.md
+++ b/examples/baseline-suppression/expected-output.md
@@ -7,21 +7,33 @@
 | Version changed | 1 |
 | License changed | 0 |
 
-### Added
+### Added (1)
+
+<details><summary>Show details</summary>
 
 | Ecosystem | Name | Version |
 |---|---|---|
 | npm | plain-crypto-js | 4.2.1 |
 
-### Removed
+</details>
+
+### Removed (1)
+
+<details><summary>Show details</summary>
 
 | Ecosystem | Name | Version |
 |---|---|---|
 | library | no-purl-component | 0.1.0 |
 
-### Version changed
+</details>
+
+### Version changed (1)
+
+<details><summary>Show details</summary>
 
 | Ecosystem | Name | Before | After |
 |---|---|---|---|
 | npm | axios | 1.14.0 | 1.14.1 |
+
+</details>
 

--- a/examples/multi-ecosystem/expected-output.md
+++ b/examples/multi-ecosystem/expected-output.md
@@ -8,7 +8,9 @@
 | License changed | 0 |
 | Possible typosquats | 4 |
 
-### Added
+### Added (4)
+
+<details><summary>Show details</summary>
 
 | Ecosystem | Name | Version |
 |---|---|---|
@@ -17,9 +19,13 @@
 | npm | crossenv | 1.0.0 |
 | pypi | requessts | 1.0.0 |
 
-### Possible typosquats
+</details>
 
-These newly added dependencies have names similar to popular packages. High similarity does not prove malicious intent — investigate the package source before merging.
+### Possible typosquats (4)
+
+<details><summary>Show details · top similarity: 0.98 (crossenv → cross-env)</summary>
+
+These newly added dependencies have names similar to popular packages. High similarity does not prove malicious intent — investigate the package source before merging. [Why this matters](https://metbcy.github.io/bomdrift/enrichers/typosquat.html)
 
 | Ecosystem | Name | Version | Similar to | Similarity |
 |---|---|---|---|---:|
@@ -27,4 +33,6 @@ These newly added dependencies have names similar to popular packages. High simi
 | maven | org.apache.commons:commons-lng3 | 1.0.0 | org.apache.commons:commons-lang3 | 0.93 |
 | npm | crossenv | 1.0.0 | cross-env | 0.98 |
 | pypi | requessts | 1.0.0 | requests | 0.95 |
+
+</details>
 

--- a/examples/version-jumps/expected-output.md
+++ b/examples/version-jumps/expected-output.md
@@ -8,7 +8,9 @@
 | License changed | 0 |
 | Multi-major version jumps | 3 |
 
-### Version changed
+### Version changed (3)
+
+<details><summary>Show details</summary>
 
 | Ecosystem | Name | Before | After |
 |---|---|---|---|
@@ -16,13 +18,19 @@
 | npm | lodash | 1.0.0 | 4.17.21 |
 | pypi | django | 3.2.0 | 5.0.0 |
 
-### Multi-major version jumps
+</details>
 
-These dependencies crossed two or more major versions in a single diff. Multi-major bumps can hide takeover swaps, namespace reuse, or large refactors that bypass the SemVer signals reviewers usually rely on. Confirm the upgrade is intentional and the source matches.
+### Multi-major version jumps (3)
+
+<details><summary>Show details</summary>
+
+These dependencies crossed two or more major versions in a single diff. Multi-major bumps can hide takeover swaps, namespace reuse, or large refactors that bypass the SemVer signals reviewers usually rely on. Confirm the upgrade is intentional and the source matches. [Why this matters](https://metbcy.github.io/bomdrift/enrichers/version-jump.html)
 
 | Ecosystem | Name | Before | After | Major bump |
 |---|---|---|---|---:|
 | cargo | clap | 2.34.0 | 4.5.0 | 2 → 4 |
 | npm | lodash | 1.0.0 | 4.17.21 | 1 → 4 |
 | pypi | django | 3.2.0 | 5.0.0 | 3 → 5 |
+
+</details>
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -132,6 +132,14 @@ pub struct DiffArgs {
     /// output.
     #[arg(long)]
     pub include_file_components: bool,
+    /// Repository URL (e.g. `https://github.com/owner/repo`) used to
+    /// render the markdown comment's action-affordance footer — the
+    /// "Report this finding" link target and the suppress-comment hint.
+    /// When unset, falls back to the `BOMDRIFT_REPO_URL` env var; when
+    /// neither is set, the footer is omitted so forks and standalone CLI
+    /// use don't render dead links to bomdrift's own issue tracker.
+    #[arg(long)]
+    pub repo_url: Option<String>,
 }
 
 /// Threshold for `--fail-on` exit-code-2 behavior.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,18 @@ fn run_diff(args: DiffArgs) -> Result<()> {
         baseline::apply(&mut cs, &mut enrichment, &baseline);
     }
 
+    // CLI flag wins; otherwise the env var supplies the default. Empty
+    // strings are treated as unset to match shell-script callers that
+    // pass `BOMDRIFT_REPO_URL=` to clear the value rather than `unset`.
+    let repo_url = args
+        .repo_url
+        .clone()
+        .or_else(|| std::env::var("BOMDRIFT_REPO_URL").ok())
+        .filter(|s| !s.is_empty());
+    let md_options = render::markdown::Options {
+        summary_only: args.summary_only,
+        repo_url,
+    };
     let rendered = match args.output {
         OutputFormat::Terminal => {
             // ANSI escapes are only safe on a real TTY. Piped/redirected stdout
@@ -89,22 +101,12 @@ fn run_diff(args: DiffArgs) -> Result<()> {
             if std::io::stdout().is_terminal() {
                 render::term::render(&cs, &enrichment)
             } else {
-                render::markdown::render_with_options(
-                    &cs,
-                    &enrichment,
-                    render::markdown::Options {
-                        summary_only: args.summary_only,
-                    },
-                )
+                render::markdown::render_with_options(&cs, &enrichment, md_options)
             }
         }
-        OutputFormat::Markdown => render::markdown::render_with_options(
-            &cs,
-            &enrichment,
-            render::markdown::Options {
-                summary_only: args.summary_only,
-            },
-        ),
+        OutputFormat::Markdown => {
+            render::markdown::render_with_options(&cs, &enrichment, md_options)
+        }
         OutputFormat::Json => render::json::render(&cs, &enrichment),
         OutputFormat::Sarif => render::sarif::render(&cs, &enrichment),
     };

--- a/src/render/markdown.rs
+++ b/src/render/markdown.rs
@@ -28,7 +28,7 @@ use crate::model::Component;
 
 /// Renderer toggles. Defaults match v0.2 behavior so existing callers keep
 /// working unchanged.
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone)]
 pub struct Options {
     /// When true, emit only the summary-counts table plus a footer note —
     /// no per-section detail tables. Compresses a several-hundred-finding
@@ -36,6 +36,13 @@ pub struct Options {
     /// reviewer follows the footer link to the full report (workflow-step
     /// summary, JSON artifact, etc.) when they need detail.
     pub summary_only: bool,
+    /// Repository URL — `https://github.com/<owner>/<repo>` form, no
+    /// trailing slash. When supplied, the renderer appends a footer
+    /// linking to a pre-filled "Report this finding" issue and the
+    /// `/bomdrift suppress <id>` comment-affordance hint. When `None`,
+    /// the footer is omitted entirely so forks / standalone CLI use
+    /// don't render dead links to bomdrift's own issue tracker.
+    pub repo_url: Option<String>,
 }
 
 pub fn render(cs: &ChangeSet, enrichment: &Enrichment) -> String {
@@ -97,25 +104,25 @@ pub fn render_with_options(cs: &ChangeSet, enrichment: &Enrichment, opts: Option
     }
 
     if !cs.added.is_empty() {
-        out.push_str("### Added\n\n");
+        section_open(&mut out, "Added", cs.added.len(), None);
         out.push_str("| Ecosystem | Name | Version |\n|---|---|---|\n");
         for c in &cs.added {
             let _ = writeln!(out, "| {} | {} | {} |", c.ecosystem, c.name, c.version);
         }
-        out.push('\n');
+        section_close(&mut out);
     }
 
     if !cs.removed.is_empty() {
-        out.push_str("### Removed\n\n");
+        section_open(&mut out, "Removed", cs.removed.len(), None);
         out.push_str("| Ecosystem | Name | Version |\n|---|---|---|\n");
         for c in &cs.removed {
             let _ = writeln!(out, "| {} | {} | {} |", c.ecosystem, c.name, c.version);
         }
-        out.push('\n');
+        section_close(&mut out);
     }
 
     if !cs.version_changed.is_empty() {
-        out.push_str("### Version changed\n\n");
+        section_open(&mut out, "Version changed", cs.version_changed.len(), None);
         out.push_str("| Ecosystem | Name | Before | After |\n|---|---|---|---|\n");
         for (b, a) in &cs.version_changed {
             let _ = writeln!(
@@ -124,15 +131,21 @@ pub fn render_with_options(cs: &ChangeSet, enrichment: &Enrichment, opts: Option
                 a.ecosystem, a.name, b.version, a.version
             );
         }
-        out.push('\n');
+        section_close(&mut out);
     }
 
     if !cs.license_changed.is_empty() {
-        out.push_str("### License changed (same version)\n\n");
+        section_open(
+            &mut out,
+            "License changed (same version)",
+            cs.license_changed.len(),
+            None,
+        );
         out.push_str(
             "Same version, different licenses — investigate. A re-publish under \
              different terms can indicate a corrected SBOM, a deliberate license \
-             change, or a supply-chain swap. Verify the source matches.\n\n",
+             change, or a supply-chain swap. Verify the source matches. \
+             [Why this matters](https://metbcy.github.io/bomdrift/output-formats.html#sarif-v210)\n\n",
         );
         out.push_str("| Ecosystem | Name | Version | Before | After |\n|---|---|---|---|---|\n");
         for (b, a) in &cs.license_changed {
@@ -146,31 +159,51 @@ pub fn render_with_options(cs: &ChangeSet, enrichment: &Enrichment, opts: Option
                 license_cell(&a.licenses),
             );
         }
-        out.push('\n');
+        section_close(&mut out);
     }
 
     if !enrichment.vulns.is_empty() {
-        out.push_str("### Vulnerabilities (added/upgraded deps)\n\n");
+        let count = enrichment.vulns.values().map(Vec::len).sum::<usize>();
+        let teaser = vuln_teaser(cs, enrichment);
+        section_open(
+            &mut out,
+            "Vulnerabilities (added/upgraded deps)",
+            count,
+            teaser.as_deref(),
+        );
         out.push_str(
             "Advisories per OSV.dev. Click each ID for details. Severity is the highest \
              of GHSA's `database_specific.severity` for that advisory; advisories that \
              pre-date the GHSA tagging or weren't reachable at lookup time render as \
-             `NONE` and don't trip `--fail-on critical-cve`.\n\n",
+             `NONE` and don't trip `--fail-on critical-cve`. \
+             [Why this matters](https://metbcy.github.io/bomdrift/enrichers/osv-cve.html)\n\n",
         );
         out.push_str("| Ecosystem | Name | Version | Advisories |\n|---|---|---|---|\n");
-        write_vuln_rows(&mut out, &cs.added, enrichment);
-        for (_, after) in &cs.version_changed {
-            write_one_vuln_row(&mut out, after, enrichment);
+        // Component-row order: highest max-severity first, then alphabetical
+        // by ecosystem+name. Per-component advisories are themselves
+        // severity-sorted in `write_one_vuln_row`. The combined ordering
+        // means Critical / High findings always cluster at the top of the
+        // table — reviewers scanning the comment see the load-bearing rows
+        // before the noise.
+        for c in vuln_components_sorted(cs, enrichment) {
+            write_one_vuln_row(&mut out, c, enrichment);
         }
-        out.push('\n');
+        section_close(&mut out);
     }
 
     if !enrichment.typosquats.is_empty() {
-        out.push_str("### Possible typosquats\n\n");
+        let teaser = typosquat_teaser(enrichment);
+        section_open(
+            &mut out,
+            "Possible typosquats",
+            enrichment.typosquats.len(),
+            teaser.as_deref(),
+        );
         out.push_str(
             "These newly added dependencies have names similar to popular packages. \
              High similarity does not prove malicious intent — investigate the package \
-             source before merging.\n\n",
+             source before merging. \
+             [Why this matters](https://metbcy.github.io/bomdrift/enrichers/typosquat.html)\n\n",
         );
         out.push_str(
             "| Ecosystem | Name | Version | Similar to | Similarity |\n|---|---|---|---|---:|\n",
@@ -178,16 +211,22 @@ pub fn render_with_options(cs: &ChangeSet, enrichment: &Enrichment, opts: Option
         for f in &enrichment.typosquats {
             write_typosquat_row(&mut out, f);
         }
-        out.push('\n');
+        section_close(&mut out);
     }
 
     if !enrichment.version_jumps.is_empty() {
-        out.push_str("### Multi-major version jumps\n\n");
+        section_open(
+            &mut out,
+            "Multi-major version jumps",
+            enrichment.version_jumps.len(),
+            None,
+        );
         out.push_str(
             "These dependencies crossed two or more major versions in a single diff. \
              Multi-major bumps can hide takeover swaps, namespace reuse, or large \
              refactors that bypass the SemVer signals reviewers usually rely on. \
-             Confirm the upgrade is intentional and the source matches.\n\n",
+             Confirm the upgrade is intentional and the source matches. \
+             [Why this matters](https://metbcy.github.io/bomdrift/enrichers/version-jump.html)\n\n",
         );
         out.push_str(
             "| Ecosystem | Name | Before | After | Major bump |\n|---|---|---|---|---:|\n",
@@ -195,18 +234,24 @@ pub fn render_with_options(cs: &ChangeSet, enrichment: &Enrichment, opts: Option
         for f in &enrichment.version_jumps {
             write_version_jump_row(&mut out, f);
         }
-        out.push('\n');
+        section_close(&mut out);
     }
 
     if !enrichment.maintainer_age.is_empty() {
-        out.push_str("### Young maintainers (added deps)\n\n");
+        section_open(
+            &mut out,
+            "Young maintainers (added deps)",
+            enrichment.maintainer_age.len(),
+            None,
+        );
         out.push_str(
             "The top contributor to each repository below opened their first commit \
              recently. The xz/liblzma backdoor (CVE-2024-3094) was authored by an \
              identity that took over maintainership after a sustained ramp-up; a \
              very-recent top contributor on a newly-introduced dependency is the \
              early signal of that pattern. Investigate the maintainer's history \
-             before merging.\n\n",
+             before merging. \
+             [Why this matters](https://metbcy.github.io/bomdrift/enrichers/maintainer-age.html)\n\n",
         );
         out.push_str(
             "| Ecosystem | Name | Version | Top contributor | Days since first commit |\n\
@@ -215,10 +260,111 @@ pub fn render_with_options(cs: &ChangeSet, enrichment: &Enrichment, opts: Option
         for f in &enrichment.maintainer_age {
             write_maintainer_age_row(&mut out, f);
         }
-        out.push('\n');
+        section_close(&mut out);
     }
 
+    write_footer(&mut out, &opts);
+
     out
+}
+
+/// Open a per-category collapsible section. The `### {label} ({count})`
+/// markdown header stays outside the `<details>` block so it remains
+/// visible (and TOC-eligible) even when the section is collapsed; the
+/// `<details>` wrapper hides the body table by default to keep the comment
+/// scannable for big diffs. `teaser` populates the `<summary>` line with
+/// the most-actionable item in the section (e.g. `top severity: CRITICAL`)
+/// so the reviewer knows whether expanding is worth their time.
+fn section_open(out: &mut String, label: &str, count: usize, teaser: Option<&str>) {
+    let _ = writeln!(out, "### {} ({})\n", label, count);
+    out.push_str("<details><summary>Show details");
+    if let Some(t) = teaser {
+        let _ = write!(out, " · {}", t);
+    }
+    // Blank line after `</summary>` is required by GitHub-Flavored Markdown
+    // for the markdown body inside `<details>` to render as markdown rather
+    // than as raw HTML. Same blank line on close.
+    out.push_str("</summary>\n\n");
+}
+
+fn section_close(out: &mut String) {
+    out.push_str("\n</details>\n\n");
+}
+
+/// Renders the comment footer with action affordances. Omitted entirely
+/// when `repo_url` is `None` so forks / standalone CLI use don't render
+/// dead links to a repo they don't own. Wrapped in `<sub>` so it doesn't
+/// compete visually with the section bodies.
+fn write_footer(out: &mut String, opts: &Options) {
+    let Some(repo) = opts.repo_url.as_deref() else {
+        return;
+    };
+    let repo = repo.trim_end_matches('/');
+    out.push_str("---\n");
+    let _ = writeln!(
+        out,
+        "<sub>**False positive?** [Report it]({repo}/issues/new?labels=false-positive&template=false-positive.md) · \
+         **Suppress a finding?** Comment `/bomdrift suppress <ID>` (requires the \
+         [comment-suppress sub-action]({repo})) · \
+         [Docs](https://metbcy.github.io/bomdrift/)</sub>",
+    );
+}
+
+/// Cross-component vulnerability ordering: components affected by the
+/// highest-severity advisory first, ties broken alphabetically by
+/// `ecosystem` then `name`. The plan calls this out explicitly: Critical /
+/// High findings should cluster at the top of the table for skimmability.
+fn vuln_components_sorted<'a>(cs: &'a ChangeSet, enrichment: &Enrichment) -> Vec<&'a Component> {
+    let mut comps: Vec<&Component> = Vec::new();
+    for c in &cs.added {
+        if !enrichment.vulns_for(c.purl.as_deref()).is_empty() {
+            comps.push(c);
+        }
+    }
+    for (_, after) in &cs.version_changed {
+        if !enrichment.vulns_for(after.purl.as_deref()).is_empty() {
+            comps.push(after);
+        }
+    }
+    comps.sort_by(|a, b| {
+        let sa = max_severity(enrichment, a);
+        let sb = max_severity(enrichment, b);
+        sb.cmp(&sa)
+            .then_with(|| a.ecosystem.to_string().cmp(&b.ecosystem.to_string()))
+            .then_with(|| a.name.cmp(&b.name))
+    });
+    comps
+}
+
+fn max_severity(enrichment: &Enrichment, c: &Component) -> crate::enrich::Severity {
+    enrichment
+        .vulns_for(c.purl.as_deref())
+        .iter()
+        .map(|v| v.severity)
+        .max()
+        .unwrap_or(crate::enrich::Severity::None)
+}
+
+fn vuln_teaser(cs: &ChangeSet, enrichment: &Enrichment) -> Option<String> {
+    let comps = vuln_components_sorted(cs, enrichment);
+    let top = comps.first()?;
+    let refs = enrichment.vulns_for(top.purl.as_deref());
+    let mut sorted: Vec<&crate::enrich::VulnRef> = refs.iter().collect();
+    sorted.sort_by(|a, b| b.severity.cmp(&a.severity).then_with(|| a.id.cmp(&b.id)));
+    let head = sorted.first()?;
+    Some(format!("top severity: {} ({})", head.severity, head.id))
+}
+
+fn typosquat_teaser(enrichment: &Enrichment) -> Option<String> {
+    let top = enrichment.typosquats.iter().max_by(|a, b| {
+        a.score
+            .partial_cmp(&b.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    })?;
+    Some(format!(
+        "top similarity: {:.2} ({} → {})",
+        top.score, top.component.name, top.closest
+    ))
 }
 
 fn write_version_jump_row(out: &mut String, f: &VersionJumpFinding) {
@@ -248,12 +394,6 @@ fn write_typosquat_row(out: &mut String, f: &TyposquatFinding) {
         "| {} | {} | {} | {} | {:.2} |",
         f.component.ecosystem, f.component.name, f.component.version, f.closest, f.score
     );
-}
-
-fn write_vuln_rows(out: &mut String, components: &[Component], enrichment: &Enrichment) {
-    for c in components {
-        write_one_vuln_row(out, c, enrichment);
-    }
 }
 
 fn write_one_vuln_row(out: &mut String, c: &Component, enrichment: &Enrichment) {
@@ -486,7 +626,14 @@ mod tests {
                 severity: crate::enrich::Severity::Critical,
             }],
         );
-        let summary = render_with_options(&cs, &e, Options { summary_only: true });
+        let summary = render_with_options(
+            &cs,
+            &e,
+            Options {
+                summary_only: true,
+                repo_url: None,
+            },
+        );
         // Summary table is preserved (the load-bearing part of the comment).
         assert!(summary.contains("## SBOM diff"));
         assert!(summary.contains("| Added | 1 |"));
@@ -507,7 +654,10 @@ mod tests {
         let out = render_with_options(
             &ChangeSet::default(),
             &Enrichment::default(),
-            Options { summary_only: true },
+            Options {
+                summary_only: true,
+                repo_url: None,
+            },
         );
         assert!(out.contains("_No dependency changes._"));
         assert!(!out.contains("Per-category detail elided"));
@@ -664,5 +814,241 @@ mod tests {
         let md = render(&cs, &Enrichment::default());
         assert!(!md.contains("### Young maintainers"));
         assert!(!md.contains("| Young maintainers |"));
+    }
+
+    // ---- Phase C: collapsible sections, cross-component vuln sort, footer ----
+
+    #[test]
+    fn sections_are_wrapped_in_collapsible_details_with_count() {
+        // Each populated section gets a `### Header (N)` line followed by
+        // a `<details><summary>Show details...</summary>` wrapper. Reviewers
+        // see the section name + count without expanding; expand to see the
+        // table.
+        let cs = ChangeSet {
+            added: vec![comp("a", "1.0", Ecosystem::Npm, None)],
+            removed: vec![comp("b", "1.0", Ecosystem::Cargo, None)],
+            version_changed: vec![(
+                comp("c", "1.0", Ecosystem::Npm, None),
+                comp("c", "2.0", Ecosystem::Npm, None),
+            )],
+            ..Default::default()
+        };
+        let md = render(&cs, &Enrichment::default());
+        assert!(md.contains("### Added (1)\n"));
+        assert!(md.contains("### Removed (1)\n"));
+        assert!(md.contains("### Version changed (1)\n"));
+        // Each opens a details block
+        let details_count = md.matches("<details>").count();
+        let summary_count = md.matches("</summary>").count();
+        let close_count = md.matches("</details>").count();
+        assert_eq!(details_count, 3);
+        assert_eq!(summary_count, 3);
+        assert_eq!(close_count, 3);
+        // Show details prefix appears in every summary line
+        assert!(md.contains("<details><summary>Show details"));
+    }
+
+    #[test]
+    fn vuln_section_summary_includes_top_severity_teaser() {
+        // The summary line must include the top severity + advisory ID so
+        // a reviewer skimming the collapsed comment knows whether to expand.
+        let cs = ChangeSet {
+            added: vec![
+                comp(
+                    "low-risk",
+                    "1.0",
+                    Ecosystem::Npm,
+                    Some("pkg:npm/low-risk@1.0"),
+                ),
+                comp("hot", "1.0", Ecosystem::Npm, Some("pkg:npm/hot@1.0")),
+            ],
+            ..Default::default()
+        };
+        let mut e = Enrichment::default();
+        e.vulns.insert(
+            "pkg:npm/low-risk@1.0".into(),
+            vec![crate::enrich::VulnRef {
+                id: "GHSA-medium".into(),
+                severity: crate::enrich::Severity::Medium,
+            }],
+        );
+        e.vulns.insert(
+            "pkg:npm/hot@1.0".into(),
+            vec![crate::enrich::VulnRef {
+                id: "CVE-2025-critical".into(),
+                severity: crate::enrich::Severity::Critical,
+            }],
+        );
+        let md = render(&cs, &e);
+        // Summary teaser cites the highest-severity advisory, not just any.
+        assert!(
+            md.contains("top severity: CRITICAL (CVE-2025-critical)"),
+            "summary line missing severity teaser; got:\n{md}"
+        );
+    }
+
+    #[test]
+    fn vuln_rows_sorted_by_max_severity_across_components() {
+        // `low-risk` is alphabetically first but only has Medium; `hot` has
+        // Critical. The Critical row must appear before the Medium row in
+        // the Vulnerabilities table — even though they appear in the
+        // opposite order in the Added section above it. Scope the search
+        // to the Vulnerabilities section to isolate the assertion.
+        let cs = ChangeSet {
+            added: vec![
+                comp(
+                    "low-risk",
+                    "1.0",
+                    Ecosystem::Npm,
+                    Some("pkg:npm/low-risk@1.0"),
+                ),
+                comp("hot", "1.0", Ecosystem::Npm, Some("pkg:npm/hot@1.0")),
+            ],
+            ..Default::default()
+        };
+        let mut e = Enrichment::default();
+        e.vulns.insert(
+            "pkg:npm/low-risk@1.0".into(),
+            vec![crate::enrich::VulnRef {
+                id: "GHSA-medium".into(),
+                severity: crate::enrich::Severity::Medium,
+            }],
+        );
+        e.vulns.insert(
+            "pkg:npm/hot@1.0".into(),
+            vec![crate::enrich::VulnRef {
+                id: "CVE-2025-critical".into(),
+                severity: crate::enrich::Severity::Critical,
+            }],
+        );
+        let md = render(&cs, &e);
+        let vuln_start = md
+            .find("### Vulnerabilities")
+            .expect("vulnerabilities section present");
+        let vuln_section = &md[vuln_start..];
+        let pos_hot = vuln_section
+            .find("| npm | hot |")
+            .expect("hot row present in vulns table");
+        let pos_low = vuln_section
+            .find("| npm | low-risk |")
+            .expect("low-risk row present in vulns table");
+        assert!(
+            pos_hot < pos_low,
+            "Critical-severity component must render before Medium-severity component within the Vulnerabilities table"
+        );
+    }
+
+    #[test]
+    fn typosquat_section_summary_includes_top_similarity_teaser() {
+        let cs = ChangeSet {
+            added: vec![
+                comp("plain-crypto-js", "4.2.1", Ecosystem::Npm, None),
+                comp("axiosx", "1.0.0", Ecosystem::Npm, None),
+            ],
+            ..Default::default()
+        };
+        let mut e = Enrichment::default();
+        e.typosquats
+            .push(crate::enrich::typosquat::TyposquatFinding {
+                component: cs.added[0].clone(),
+                closest: "crypto-js".to_string(),
+                score: 0.95,
+            });
+        e.typosquats
+            .push(crate::enrich::typosquat::TyposquatFinding {
+                component: cs.added[1].clone(),
+                closest: "axios".to_string(),
+                score: 0.85,
+            });
+        let md = render(&cs, &e);
+        // Top score (0.95) wins — that's the actionable finding to surface
+        // in the collapsed summary line.
+        assert!(
+            md.contains("top similarity: 0.95 (plain-crypto-js → crypto-js)"),
+            "typosquat summary missing teaser; got:\n{md}"
+        );
+    }
+
+    #[test]
+    fn footer_omitted_when_repo_url_unset() {
+        let cs = ChangeSet {
+            added: vec![comp("a", "1.0", Ecosystem::Npm, None)],
+            ..Default::default()
+        };
+        let md = render(&cs, &Enrichment::default());
+        assert!(!md.contains("False positive?"));
+        assert!(!md.contains("/issues/new"));
+    }
+
+    #[test]
+    fn footer_renders_when_repo_url_supplied() {
+        let cs = ChangeSet {
+            added: vec![comp("a", "1.0", Ecosystem::Npm, None)],
+            ..Default::default()
+        };
+        let md = render_with_options(
+            &cs,
+            &Enrichment::default(),
+            Options {
+                summary_only: false,
+                repo_url: Some("https://github.com/example/proj".to_string()),
+            },
+        );
+        assert!(md.contains("False positive?"));
+        assert!(md.contains("https://github.com/example/proj/issues/new"));
+        assert!(md.contains("/bomdrift suppress"));
+        assert!(md.contains("https://metbcy.github.io/bomdrift/"));
+    }
+
+    #[test]
+    fn footer_strips_trailing_slash_from_repo_url() {
+        // Forks and fork-of-forks may pass a URL with a trailing slash;
+        // produce the same `/issues/new` suffix regardless.
+        let cs = ChangeSet {
+            added: vec![comp("a", "1.0", Ecosystem::Npm, None)],
+            ..Default::default()
+        };
+        let md = render_with_options(
+            &cs,
+            &Enrichment::default(),
+            Options {
+                summary_only: false,
+                repo_url: Some("https://github.com/example/proj/".to_string()),
+            },
+        );
+        assert!(md.contains("https://github.com/example/proj/issues/new"));
+        assert!(!md.contains("proj//issues"));
+    }
+
+    #[test]
+    fn why_this_matters_link_appears_in_each_finding_section() {
+        let cs = ChangeSet {
+            added: vec![comp(
+                "vuln",
+                "1.0",
+                Ecosystem::Npm,
+                Some("pkg:npm/vuln@1.0"),
+            )],
+            ..Default::default()
+        };
+        let mut e = Enrichment::default();
+        e.vulns.insert(
+            "pkg:npm/vuln@1.0".into(),
+            vec![crate::enrich::VulnRef {
+                id: "GHSA-x".into(),
+                severity: crate::enrich::Severity::High,
+            }],
+        );
+        e.typosquats
+            .push(crate::enrich::typosquat::TyposquatFinding {
+                component: cs.added[0].clone(),
+                closest: "vulnx".to_string(),
+                score: 0.9,
+            });
+        let md = render(&cs, &e);
+        // SARIF helpUri reuse — the same docs URL should appear in markdown
+        // so reviewers can click through to the per-rule explanation.
+        assert!(md.contains("https://metbcy.github.io/bomdrift/enrichers/osv-cve.html"));
+        assert!(md.contains("https://metbcy.github.io/bomdrift/enrichers/typosquat.html"));
     }
 }


### PR DESCRIPTION
## Summary

Phase C of the v0.5 OSS-adoption milestone (`~/.claude/plans/bomdrift-v0.5-adoption.md`). UX polish on the markdown comment that the action posts:

- Each per-category section wrapped in `<details><summary>Show details ...</summary>` so big diffs are skim-friendly. `### Header (count)` stays visible above the wrapper.
- Vulnerability rows now sorted by max-severity DESC across components — Critical / High cluster at the top of the table.
- New `<summary>` teasers surface the most-actionable item in each finding section (`top severity: CRITICAL (...)`, `top similarity: 0.95 (...)`) so reviewers know whether to expand without clicking.
- Per-section "Why this matters" links reuse the SARIF helpUris from v0.4.2 — same docs URL across both output formats.
- New `--repo-url` flag (also reads `BOMDRIFT_REPO_URL` env var) renders an action-affordance footer with a pre-filled "Report this finding" issue link, the `/bomdrift suppress <id>` hint (Phase D's mechanism), and a Docs link. Footer omitted entirely when unset so forks don't render dead links.

## Test plan

- [x] `cargo test --release` — 236 lib tests + 7 real-world + 24 bin/integration pass (8 new tests in markdown.rs)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `bash examples/run-all.sh` — all 4 scenarios pass with regenerated `expected-output.md` files
- [ ] Visual review of the rendered comment on a real PR (best done after merge — none of the v0.4 callers pass `--repo-url`, so footer-rendering needs a deliberate wire-up in the action's entrypoint, deferred to Phase D's release polish)

## Pinned decisions

- **Collapsible by default, not opt-in.** Plan said "skimmable for big diffs" — that's the goal. A pre-merge round-trip on a small diff (say PR #1's humantime add) shows the collapsed form working without any consumer config.
- **Header outside the details block.** Both `### Added (5)\n<details>` and `<details><summary>### Added (5)</summary>` were considered. The latter renders `### Added (5)` as literal text inside `<summary>` (GFM doesn't render markdown inside `<summary>`). Headers stay outside → table-of-contents and visual scan still work.
- **Footer omission when `repo_url == None`.** Forks and the JSON / SARIF outputs already do not render the markdown footer, but a fork that *does* use markdown doesn't want bomdrift's repo as the "Report it" target. Opt-in URL keeps the surface honest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)