### PR TITLE
chore(release): prepare v0.6.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/action-broke.md
+++ b/.github/ISSUE_TEMPLATE/action-broke.md
@@ -36,6 +36,6 @@ failure is usually obvious if you expand all groups. -->
 
 ## Environment
 
-- **bomdrift version pin**: `@v1` / `@v0.5.0` / `@<sha>`
+- **bomdrift version pin**: `@v1` / `@v0.6.0` / `@<sha>`
 - **Runner**: <ubuntu-latest / self-hosted / etc.>
 - **Trigger event**: <pull_request / push / workflow_dispatch / etc.>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-04-29
+
 ### Added
 
 - **Repository policy config (`.bomdrift.toml`).** `bomdrift diff`
@@ -607,7 +609,8 @@ changed dependency in a format ready to drop into a PR comment.
 - Linux aarch64 binary.
 - PyPI / Cargo / Maven typosquat reference lists (only npm in v0.1.0).
 
-[Unreleased]: https://github.com/Metbcy/bomdrift/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/Metbcy/bomdrift/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/Metbcy/bomdrift/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/Metbcy/bomdrift/compare/v0.4.4...v0.5.0
 [0.4.4]: https://github.com/Metbcy/bomdrift/releases/tag/v0.4.4
 [0.4.3]: https://github.com/Metbcy/bomdrift/releases/tag/v0.4.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,7 +114,7 @@ checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bomdrift"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bomdrift"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 rust-version = "1.85"
 description = "SBOM diff with supply-chain risk signals (CVEs, typosquats, maintainer-age)."

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ jobs:
         #   verify-signatures: true   (set false on trusted mirrors)
 ```
 
-Pin to `@v1` for the latest v0.x; pin to `@v0.5.0` for reproducible builds. Run `bomdrift init` if you want a checked-in `.bomdrift.toml` policy and both workflows scaffolded locally. See the [Action reference](https://metbcy.github.io/bomdrift/github-action.html) for every input.
+Pin to `@v1` for the latest v0.x; pin to `@v0.6.0` for reproducible builds. Run `bomdrift init` if you want a checked-in `.bomdrift.toml` policy and both workflows scaffolded locally. See the [Action reference](https://metbcy.github.io/bomdrift/github-action.html) for every input.
 
 #### Optional: in-comment suppression (v0.5+)
 
@@ -112,7 +112,7 @@ Comment `/bomdrift suppress GHSA-xxxx` on any PR; the sub-action appends to `.bo
 Pre-built binaries cover Linux x86_64 + aarch64, macOS aarch64, and Windows x86_64. Each archive is cosign-signed via Sigstore + GitHub OIDC.
 
 ```bash
-VERSION=v0.5.0
+VERSION=v0.6.0
 TARGET=x86_64-unknown-linux-gnu
 curl -sSL -o bomdrift.tar.gz \
   "https://github.com/Metbcy/bomdrift/releases/download/${VERSION}/bomdrift-${VERSION}-${TARGET}.tar.gz"
@@ -128,7 +128,7 @@ Verify the archive's signature before you trust the binary — see [Release sign
 ### From source
 
 ```bash
-cargo install --locked --git https://github.com/Metbcy/bomdrift --tag v0.5.0 bomdrift
+cargo install --locked --git https://github.com/Metbcy/bomdrift --tag v0.6.0 bomdrift
 ```
 
 Requires Rust 1.85+ (the project uses edition 2024).
@@ -230,7 +230,7 @@ Every release archive is signed with cosign keyless via Sigstore (GitHub OIDC).
 
 ```bash
 # Replace VERSION + TARGET with your downloaded archive's pair
-VERSION=v0.5.0
+VERSION=v0.6.0
 TARGET=x86_64-unknown-linux-gnu
 ARCHIVE=bomdrift-${VERSION}-${TARGET}.tar.gz
 

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -25,7 +25,7 @@ jobs:
 ```
 
 The `@v1` mutable tag tracks the latest v0.x release. Pin to a specific
-version (`@v0.5.0`) if you prefer reproducible builds. See
+version (`@v0.6.0`) if you prefer reproducible builds. See
 [GitHub Action](./github-action.md) for every input.
 
 If you prefer a checked-in policy file, install the binary and run
@@ -39,7 +39,7 @@ Pre-built binaries cover Linux x86_64 + aarch64, macOS aarch64, and
 Windows x86_64. Each archive is cosign-signed via Sigstore + GitHub OIDC.
 
 ```bash
-VERSION=v0.5.0
+VERSION=v0.6.0
 TARGET=x86_64-unknown-linux-gnu
 curl -sSL -o bomdrift.tar.gz \
   "https://github.com/Metbcy/bomdrift/releases/download/${VERSION}/bomdrift-${VERSION}-${TARGET}.tar.gz"
@@ -56,7 +56,7 @@ To verify the archive's signature before you trust the binary, see
 ## From source
 
 ```bash
-cargo install --locked --git https://github.com/Metbcy/bomdrift --tag v0.5.0 bomdrift
+cargo install --locked --git https://github.com/Metbcy/bomdrift --tag v0.6.0 bomdrift
 ```
 
 Requires Rust 1.85+ (the project uses edition 2024).


### PR DESCRIPTION
## Summary
- bump crate/docs pins to v0.6.0
- move v0.6 adoption controls changelog entries under the v0.6.0 release heading

## Validation
- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --release`
- `bash examples/run-all.sh`
- `${CARGO_HOME:-$HOME/.cargo}/bin/mdbook build docs`
- `bash -n entrypoint.sh && bash -n comment-suppress/entrypoint.sh`
- `action.yml` parsed with PyYAML