### PR TITLE
fix(config): tolerate missing baseline file from .bomdrift.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **First PR after `bomdrift init` no longer fails when no baseline
+  has been suppressed yet.** `bomdrift init` ships a `.bomdrift.toml`
+  with `baseline = ".bomdrift/baseline.json"` — the path the
+  `/bomdrift suppress` flow writes to. Before this fix, the diff
+  hard-failed with `reading baseline file: ... No such file or
+  directory` on every PR until a reviewer used the suppress comment
+  at least once. Config-derived baseline paths are now tolerant of a
+  missing file (the diff runs with no suppressions applied), while
+  CLI `--baseline path` keeps its strict typo-detector behavior.
+
 ## [0.6.0] - 2026-04-29
 
 ### Added

--- a/src/config.rs
+++ b/src/config.rs
@@ -61,7 +61,16 @@ fn apply_loaded_diff_config(args: &mut DiffArgs, config: Config) {
     args.no_osv |= diff.no_osv.unwrap_or(false);
     args.no_osv_cache |= diff.no_osv_cache.unwrap_or(false);
     if args.baseline.is_none() {
-        args.baseline = diff.baseline;
+        // Config-derived baseline paths are tolerant of a missing file.
+        // `bomdrift init` ships `.bomdrift.toml` pointing at
+        // `.bomdrift/baseline.json` before any `/bomdrift suppress`
+        // comment has had a chance to create it; failing the very first
+        // PR-comment run because the file doesn't exist yet would defeat
+        // the whole point of the scaffolded default. CLI `--baseline
+        // path` remains strict (a typo'd path silently no-op'ing is the
+        // worse footgun there) — that strict behavior lives in
+        // `Baseline::load` and is unchanged.
+        args.baseline = diff.baseline.filter(|p| p.exists());
     }
     args.no_maintainer_age |= diff.no_maintainer_age.unwrap_or(false);
     if args.fail_on.is_none() {
@@ -156,6 +165,47 @@ mod tests {
         assert_eq!(diff.no_osv, Some(true));
         assert_eq!(diff.findings_only, Some(true));
         assert_eq!(diff.max_added, Some(10));
+    }
+
+    #[test]
+    fn config_baseline_path_is_dropped_when_file_missing() {
+        // Repro of the v0.6.0 rough edge: `bomdrift init` writes
+        // `.bomdrift.toml` with `baseline = ".bomdrift/baseline.json"`
+        // but the file doesn't exist yet (it's created on the first
+        // `/bomdrift suppress` comment). The first PR-comment run on a
+        // freshly-init'd repo must NOT fail before rendering — the diff
+        // should run with no baseline applied.
+        let mut args = args();
+        let diff = DiffConfig {
+            baseline: Some(PathBuf::from(
+                "/nonexistent/this/path/should/not/exist/baseline.json",
+            )),
+            ..Default::default()
+        };
+        let config = Config { diff: Some(diff) };
+        apply_loaded_diff_config(&mut args, config);
+        assert!(
+            args.baseline.is_none(),
+            "config-derived baseline pointing at a missing file must be dropped, not propagated"
+        );
+    }
+
+    #[test]
+    fn config_baseline_path_is_kept_when_file_exists() {
+        let mut args = args();
+        let tmp = std::env::temp_dir();
+        let path = tmp.join("bomdrift-config-baseline-fixture.json");
+        std::fs::write(&path, "{}").expect("write fixture baseline");
+
+        let diff = DiffConfig {
+            baseline: Some(path.clone()),
+            ..Default::default()
+        };
+        let config = Config { diff: Some(diff) };
+        apply_loaded_diff_config(&mut args, config);
+        assert_eq!(args.baseline.as_deref(), Some(path.as_path()));
+
+        std::fs::remove_file(&path).ok();
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -758,3 +758,88 @@ fn diff_fail_on_license_change_exits_2() {
 
     fs::remove_dir_all(dir).ok();
 }
+
+#[test]
+fn diff_explicit_baseline_path_missing_errors_loudly() {
+    // Regression guard for the v0.6.1 baseline split: CLI `--baseline
+    // <path>` MUST keep its strict typo-detector behavior even after
+    // config-supplied baselines were softened. A user who types
+    // `--baseline pasleline.json` (typo) deserves a hard failure, not a
+    // silent run with no suppressions applied.
+    let out = Command::new(bin())
+        .current_dir(manifest_dir())
+        .args([
+            "diff",
+            "tests/fixtures/cdx-minimal.json",
+            "tests/fixtures/cdx-after.json",
+            "--baseline",
+            "tests/fixtures/does-not-exist-baseline.json",
+            "--no-osv",
+            "--no-maintainer-age",
+        ])
+        .output()
+        .expect("spawn bomdrift");
+
+    assert!(
+        !out.status.success(),
+        "explicit --baseline pointing at a missing file must error; got status {}",
+        out.status
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("does-not-exist-baseline.json"),
+        "stderr should name the missing baseline path; got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("reading baseline file"),
+        "stderr should explain the baseline read failure; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn diff_config_baseline_missing_file_does_not_error() {
+    // End-to-end repro of the v0.6.1 fix: `bomdrift init` writes
+    // `.bomdrift.toml` with `baseline = ".bomdrift/baseline.json"` —
+    // a path that doesn't exist until the first `/bomdrift suppress`
+    // comment populates it. The first PR-comment run on a freshly
+    // init'd repo must succeed and render markdown with no
+    // suppressions applied, NOT fail with "No such file or directory".
+    let dir = temp_dir("config-baseline-missing");
+    fs::write(
+        dir.join(".bomdrift.toml"),
+        r#"
+        [diff]
+        no_osv = true
+        no_maintainer_age = true
+        baseline = ".bomdrift/baseline.json"
+        "#,
+    )
+    .expect("write config");
+
+    let out = Command::new(bin())
+        .current_dir(&dir)
+        .args([
+            "diff",
+            &fixture_path("cdx-minimal.json"),
+            &fixture_path("cdx-after.json"),
+        ])
+        .output()
+        .expect("spawn bomdrift");
+
+    assert!(
+        out.status.success(),
+        "config-supplied missing baseline must not block render; got status {} stderr:\n{}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("reading baseline file"),
+        "config-tolerant path must not surface the strict-mode error; got:\n{stderr}"
+    );
+    let stdout = String::from_utf8(out.stdout).expect("stdout is utf-8");
+    assert!(stdout.starts_with("## SBOM diff"));
+    assert!(stdout.contains("plain-crypto-js"));
+
+    fs::remove_dir_all(dir).ok();
+}


### PR DESCRIPTION
## Summary

Surfaced via dogfooding `bomdrift init` in a scratch repo: the very first PR-comment run on a freshly-init'd repo fails before rendering with `reading baseline file: .bomdrift/baseline.json — No such file or directory`. `bomdrift init` writes `.bomdrift.toml` pointing at the suppression baseline path, but that file is only created on the first `/bomdrift suppress` comment — so users hit a confusing exit-1 immediately after following the documented init flow.

Fix: in `apply_loaded_diff_config`, drop the config-supplied baseline path when the file doesn't exist. The diff runs with no suppressions applied — the right semantic for "nothing has been suppressed yet." CLI `--baseline path` keeps its strict typo-detector behavior (`Baseline::load` is untouched), so users who explicitly point at a typo'd path still fail loudly.

## Test plan

- [x] `cargo test --release` — 250+ lib tests pass; 2 new unit tests in `config::tests` cover the missing-file (path dropped) and existing-file (path kept) cases
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `bash examples/run-all.sh` — all 4 scenarios pass
- [x] **End-to-end repro:** scratch repo `git init` + `bomdrift init` + `bomdrift diff` against fixtures — fails on `main` (exit 1, confusing error), succeeds on this branch (exit 0, full markdown diff rendered)
- [x] **CLI strict-mode regression guard:** `bomdrift diff --baseline /nonexistent/path` still exits 1 with the same error message — explicit user-supplied paths remain strict

🤖 Generated with [Claude Code](https://claude.com/claude-code)