### PR TITLE
docs(contributing): commit-signing on main expectations

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,6 +21,16 @@ than what the diff does — `git diff` shows the what. -->
 - [ ] `bash examples/run-all.sh` clean (if behavior or rendered-output changes touched the example fixtures)
 - [ ] `mdbook build docs` clean (if any `docs/src/**.md` changed)
 
+<!--
+Note for the merging maintainer: `main` enforces required_signatures.
+Use `--merge` or `--squash` when merging this PR (GitHub's web-UI key
+signs those commits). Only use `--rebase` if every commit on this
+branch is already signed by the contributor — otherwise the rule
+blocks the rebase. Contributors are NOT expected to sign their own
+commits; see CONTRIBUTING.md "Commit signing on `main`" for the
+full picture.
+-->
+
 ## Linked issues
 
 <!-- "Closes #123" or "Refs #456" -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,36 @@ Commit bodies should explain *why*, not *what* — `git diff` shows the
 *what*. Multi-line commit messages are fine; use the heredoc
 `git commit -m "$(cat <<'EOF' ... EOF)"` pattern for readability.
 
+### Commit signing on `main`
+
+`main` enforces `required_signatures` via the repository ruleset.
+**This does NOT mean PR contributors need GPG/SSH signing keys
+configured.** Here's how it actually shakes out:
+
+| You're a... | Do you need to sign? |
+|---|---|
+| Contributor opening a PR from a fork or feature branch | **No.** Push commits as-is. The maintainer chooses the merge method. |
+| Maintainer merging via `gh pr merge --merge` | **No.** GitHub's web-UI key signs the merge commit; it counts as verified. |
+| Maintainer merging via `gh pr merge --squash` | **No.** Same — GitHub signs the squash commit. |
+| Maintainer merging via `gh pr merge --rebase` | **Yes.** Rebase replays your PR commits verbatim onto `main`, so they must already be signed. |
+| Anyone pushing directly to `main` | **Yes** (and the ruleset blocks it via `pull_request` anyway, so this only matters for emergency bypass). |
+
+Practical rule of thumb for contributors: **don't worry about it**.
+The maintainer will pick the right merge method.
+
+If you'd like your commits to land verbatim on `main` for git-blame
+attribution (and want to use rebase-merge), set up local signing once:
+
+```bash
+# SSH-key signing (simplest, no GPG headache)
+git config --global gpg.format ssh
+git config --global user.signingkey ~/.ssh/id_ed25519.pub
+git config --global commit.gpgsign true
+```
+
+Then add the same SSH public key to your GitHub account under
+[SSH and GPG keys → Signing keys](https://github.com/settings/keys).
+
 ### Branch model
 
 Single-purpose feature branches off `main`, merged via merge-commits


### PR DESCRIPTION
## What this PR does

Adds a "Commit signing on \`main\`" section to CONTRIBUTING.md and a reviewer note to the PR template explaining how the new ruleset's \`required_signatures\` rule interacts with the PR-and-merge flow.

**Net effect for contributors: nothing changes.** They don't need to set up GPG/SSH signing before opening a PR. The maintainer chooses \`--merge\` or \`--squash\` at merge time (both produce GitHub-signed commits that satisfy the rule). \`--rebase\` is the only path that requires pre-signed commits, so the PR template reminder mentions that.

## What it covers

- A who-needs-to-sign-when matrix in CONTRIBUTING.md (covers contributors / squash maintainer / merge maintainer / rebase maintainer / direct-push edge case).
- One-time SSH signing setup snippet for contributors who *want* their commits verbatim on main (git-blame attribution).
- A commented-out reviewer note in the PR template reminding the merging maintainer to pick \`--merge\` or \`--squash\`.

## Test coverage

- [x] No new tests (docs-only)

## Verification gates

- [x] No code touched; cargo gates not affected.

## Linked issues

n/a — proactive note addressing the new ruleset's \`required_signatures\` rule.

## Anything reviewers should know

When you merge this, **use \`gh pr merge --merge\` or \`--squash\`** (the documented happy path). \`--rebase\` would fail because the docs-branch commit isn't locally signed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>