### PR TITLE
fix(ci): coverage comment no longer autolinks to a fake domain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,11 +46,14 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --all-features
 
-  # Informational coverage report. Emits lcov.info as an artifact and
-  # posts a sticky PR comment with the line-coverage %. Intentionally
-  # NOT in the required-status-checks list and NOT using
-  # `--fail-under-lines` — let the number be visible across 2-3
-  # releases before ratcheting (see CONTRIBUTING.md "Coverage").
+  # Informational coverage report. Emits the lcov file as an artifact
+  # (named `coverage-lcov` — NOT `lcov.info`, since the bare `.info` TLD
+  # gets autolinked to a fake parked domain by email/feed renderers that
+  # strip Markdown backticks) and posts a sticky PR comment with the
+  # line-coverage %. Intentionally NOT in the required-status-checks
+  # list and NOT using `--fail-under-lines` — let the number be visible
+  # across 2-3 releases before ratcheting (see CONTRIBUTING.md
+  # "Coverage").
   coverage:
     runs-on: ubuntu-latest
     steps:
@@ -66,7 +69,7 @@ jobs:
       - name: Upload lcov artifact
         uses: actions/upload-artifact@v4
         with:
-          name: lcov.info
+          name: coverage-lcov
           path: lcov.info
           retention-days: 30
       - name: Compute coverage %
@@ -92,7 +95,7 @@ jobs:
 
             Line coverage: **${{ steps.compute.outputs.pct }}%** (${{ steps.compute.outputs.covered }} / ${{ steps.compute.outputs.total }} lines)
 
-            Full lcov report available as workflow artifact `lcov.info`.
+            Full lcov report available as workflow artifact **coverage-lcov**: [download from this run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts).
 
             <sub>v0.9.8 introduces this report; `--fail-under-lines` will be added once coverage is visible across 2–3 releases.</sub>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Coverage-report PR comment no longer autolinks to a fake parked
+  domain.** v0.9.8's coverage job uploaded the report under an
+  artifact name that ended in a real TLD and rendered the same string
+  in its sticky PR comment. Inside GitHub's web UI the backticks made
+  it inline code, but email and feed clients re-render comments with
+  their own autolinker that ignores backticks, so the bare
+  TLD-shaped token got linked to a real, unrelated parked domain and
+  produced exactly the kind of supply-chain-credibility hit a security
+  tool can't afford. The artifact is now named `coverage-lcov` (the
+  on-disk filename is still the standard one, so lcov-consuming tools
+  work unchanged), and the comment links directly to the workflow
+  run's artifacts tab so users have a real destination to follow.
+
 ## [0.9.8] - 2026-04-30
 
 The "code-review-driven hardening" milestone. External agent review surfaced
@@ -25,7 +40,7 @@ items, defers the rest as v1.0+ candidates with explicit rationale.
   Nightly Rust toolchain pinned per cargo-fuzz convention. Closes the
   textbook "untrusted-input parser" gap for a security tool.
 - **CI coverage report.** New `coverage` job in `.github/workflows/ci.yml`
-  runs `cargo-llvm-cov`, emits `lcov.info` as a workflow artifact, and posts
+  runs `cargo-llvm-cov`, emits the lcov report as a workflow artifact, and posts
   a sticky PR comment via `marocchino/sticky-pull-request-comment@v2` showing
   line-coverage percentage. **No `--fail-under-lines` gate yet** — coverage
   is informational for v0.9.8/v0.9.9 to establish a stable baseline before

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,8 +136,12 @@ matters and silently breaking it would be an easy regression.
 ### Coverage (v0.9.8+)
 
 CI runs `cargo llvm-cov` on every PR and posts a sticky comment with
-the overall line coverage % (the full `lcov.info` is uploaded as a
-workflow artifact). The job is informational for now — there is no
+the overall line coverage % (the full lcov report is uploaded as the
+`coverage-lcov` workflow artifact — the artifact name intentionally
+avoids the standard lcov-output filename, since email/feed renderers
+that strip Markdown backticks autolink anything ending in a TLD and
+that filename's extension resolves to a real, unrelated parked
+domain). The job is informational for now — there is no
 `--fail-under-lines` threshold yet. The plan is to add a ratchet in
 v0.9.9 once 2–3 releases have made the baseline visible. Until then,
 the report is a nudge, not a gate; PRs that move coverage in the


### PR DESCRIPTION
## Reported behavior

After the v0.9.8 release notification landed in the maintainer's inbox, the coverage-report PR comment was rendering the lcov artifact name as a hyperlink in email — pointing at a real, unrelated parked domain. Exactly the kind of supply-chain-credibility hit a security tool can't afford.

## Root cause

The sticky coverage comment includes the workflow artifact name verbatim. In GitHub's web UI the backticks make it inline code, but email and feed clients re-render the comment with their own autolinker that strips backticks and matches anything ending in a registered TLD. Because the standard lcov filename ends in a TLD, the literal token was getting linked to a real, unrelated domain.

## Fix

- Rename the upload-artifact bundle to `coverage-lcov`. The on-disk filename stays unchanged so lcov-consuming tools (vscode-coverage-gutters, codecov, etc.) still find it inside the artifact.
- Replace the bare token in the comment with a direct link to the workflow run's `#artifacts` tab. Email readers now have a safe destination.
- Sanitize CONTRIBUTING.md and CHANGELOG.md to keep the same fix from leaking back through release-notes emails / RSS feeds.
- Internal `ci.yml` references (`--output-path`, `path:`, shell parsing) keep the on-disk filename. They're never rendered to email and changing them would break lcov format consumers.

## Validation

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` parses clean.
- This PR's own coverage comment is the dogfood — once CI lands, the sticky comment should show the workflow-run link rather than the bare token.
