### PR TITLE
chore(ci): opt every workflow into the Node.js 24 runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,13 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -D warnings
+  # Opt every JavaScript-based action in this workflow into the Node.js 24
+  # runner ahead of GitHub's 2026-06-02 forced-default. Silences the
+  # "Node.js 20 actions are deprecated" warning the runner emits on every
+  # checkout / upload-artifact / sticky-pull-request-comment step. Remove
+  # once Node.js 24 is the default runtime.
+  # https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
   fmt:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,6 +14,13 @@ permissions:
   pages: write
   id-token: write
 
+env:
+  # Opt every JavaScript-based action in this workflow into the Node.js 24
+  # runner ahead of GitHub's 2026-06-02 forced-default. See ci.yml for the
+  # full rationale.
+  # https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 # Allow only one concurrent deployment, skipping in-flight runs but always
 # letting the most recent push reach production. Manually-dispatched runs
 # fall outside the cancel-in-progress to support targeted re-deploys.

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -17,6 +17,13 @@ on:
 permissions:
   contents: read
 
+env:
+  # Opt every JavaScript-based action in this workflow into the Node.js 24
+  # runner ahead of GitHub's 2026-06-02 forced-default. See ci.yml for the
+  # full rationale.
+  # https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   fuzz:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,11 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
   RUST_BACKTRACE: 1
+  # Opt every JavaScript-based action in this workflow into the Node.js 24
+  # runner ahead of GitHub's 2026-06-02 forced-default. See ci.yml for the
+  # full rationale.
+  # https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
   preflight:

--- a/.github/workflows/sbom-diff.yml
+++ b/.github/workflows/sbom-diff.yml
@@ -25,6 +25,13 @@ permissions:
   contents: read
   pull-requests: write       # to upsert the diff comment
 
+env:
+  # Opt every JavaScript-based action in this workflow into the Node.js 24
+  # runner ahead of GitHub's 2026-06-02 forced-default. See ci.yml for the
+  # full rationale.
+  # https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 concurrency:
   group: sbom-diff-${{ github.event.pull_request.number }}
   cancel-in-progress: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **Workflows opt into the Node.js 24 runner ahead of GitHub's
+  2026-06-02 forced-default.** Every workflow now sets
+  `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'` at the top-level
+  `env:` block, silencing the runner's "Node.js 20 actions are
+  deprecated" warning that was firing on every `actions/checkout`,
+  `upload-artifact`, and sticky-pull-request-comment step. Covers
+  `ci.yml`, `docs.yml`, `fuzz.yml`, `release.yml`, and
+  `sbom-diff.yml`. Remove the env var once Node.js 24 is the default
+  runtime (after 2026-09-16 per GitHub's deprecation timeline).
+
 ### Fixed
 
 - **Coverage-report PR comment no longer autolinks to a fake parked


### PR DESCRIPTION
## Summary

Opts every workflow into the Node.js 24 runner ahead of GitHub's 2026-06-02 forced-default. Silences the runner-level warning that's been firing on every `actions/checkout`, `upload-artifact`, and sticky-pull-request-comment step in v0.9.8's CI.

## Why this approach

GitHub's [deprecation note](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) explicitly recommends `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` as the early-opt-in path. It covers every JavaScript-based action in the workflow at once — both `actions/*` (checkout, upload-artifact, download-artifact, upload-pages-artifact, deploy-pages) and 3rd-party (rustsec/audit-check, EmbarkStudios/cargo-deny-action, sigstore/cosign-installer, marocchino/sticky-pull-request-comment, softprops/action-gh-release, Swatinem/rust-cache) — without per-action major-version bumps and the migration risk those bring.

The forced-default lands 2026-06-02 and Node.js 20 is removed entirely 2026-09-16, so this is a temporary shim with a known sunset date. The CHANGELOG entry calls that out.

## Files

| File | Change |
|---|---|
| `.github/workflows/ci.yml` | Append env var to existing `env:` block |
| `.github/workflows/docs.yml` | Add new `env:` block (no existing one) |
| `.github/workflows/fuzz.yml` | Add new `env:` block (no existing one) |
| `.github/workflows/release.yml` | Append env var to existing `env:` block |
| `.github/workflows/sbom-diff.yml` | Add new `env:` block (no existing one) |
| `CHANGELOG.md` | New `[Unreleased]` Changed entry |

## Validation

All five workflow YAMLs parse clean under PyYAML (`yaml.safe_load`); `jobs:` and `env:` keys preserved correctly.

This PR's own CI run is the dogfood — once it lands, the deprecation warning should be absent from the run logs.
