### PR TITLE
test(enrich,model): close coverage gaps in sbom.rs and kev.rs

### DIFF
--- a/src/enrich/kev.rs
+++ b/src/enrich/kev.rs
@@ -233,4 +233,170 @@ mod tests {
         apply_kev(&mut e, &HashSet::new());
         assert!(!e.vulns["pkg:npm/foo@1"][0].kev);
     }
+
+    fn tempdir_unique(stem: &str) -> PathBuf {
+        let p = std::env::temp_dir().join(format!(
+            "bomdrift-kev-test-{stem}-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        std::fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    #[test]
+    fn enrich_short_circuits_when_vulns_empty() {
+        // No vulns in the enrichment means there's nothing to flag, so the
+        // public `enrich` entry point must return Ok without touching the
+        // network or cache. This guards against a regression where an empty
+        // changeset accidentally fires a KEV-feed fetch on every diff.
+        let mut e = Enrichment::default();
+        // `enrich` is the public entry point — it eventually delegates to
+        // `enrich_with_url` whose first action is the empty-vulns check, so
+        // calling `enrich` directly exercises the short-circuit through the
+        // full call chain (lines 42->48->58).
+        let result = enrich(&mut e);
+        assert!(result.is_ok());
+        assert!(e.vulns.is_empty());
+    }
+
+    #[test]
+    fn enrich_with_ttl_short_circuits_when_vulns_empty() {
+        // Mirror of the previous test for the ttl-aware entry point. The
+        // `--cache-ttl-hours` callers go through this signature, so the
+        // empty-vulns short circuit must hold here too — otherwise a
+        // user-supplied TTL on an empty diff would still hit the network.
+        let mut e = Enrichment::default();
+        let result = enrich_with_ttl(&mut e, Some(48));
+        assert!(result.is_ok());
+        assert!(e.vulns.is_empty());
+    }
+
+    #[test]
+    fn enrich_with_url_swallows_network_failure() {
+        // Best-effort contract: when the KEV feed is unreachable, the
+        // enricher logs (only when `BOMDRIFT_DEBUG` is set, to avoid
+        // spamming PR comments) and returns Ok with no enrichment. A
+        // failing fetch must NOT poison the diff. We point at a port
+        // that's nearly guaranteed to refuse-connect on every runner
+        // (port 1, the historical TCPMUX port; never bound on
+        // GitHub-hosted runners) with a 1s timeout, then assert the
+        // VulnRef survives un-flagged.
+        let mut e = Enrichment::default();
+        let mut vulns: HashMap<String, Vec<VulnRef>> = HashMap::new();
+        vulns.insert(
+            "pkg:npm/foo@1".into(),
+            vec![VulnRef {
+                id: "GHSA-xxxx-yyyy-zzzz".into(),
+                severity: Severity::High,
+                aliases: vec!["CVE-2024-1111".into()],
+                epss_score: None,
+                kev: false,
+            }],
+        );
+        e.vulns = vulns;
+        let result = enrich_with_url(
+            &mut e,
+            "http://127.0.0.1:1/kev.json",
+            Duration::from_millis(500),
+            None,
+        );
+        assert!(result.is_ok());
+        assert!(
+            !e.vulns["pkg:npm/foo@1"][0].kev,
+            "network failure must not flag refs as KEV"
+        );
+    }
+
+    #[test]
+    fn read_cache_returns_none_when_file_missing() {
+        let dir = tempdir_unique("read-missing");
+        let path = dir.join("nope.json");
+        assert!(read_cache(&path, 86_400).is_none());
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn read_cache_returns_ids_when_within_ttl() {
+        let dir = tempdir_unique("read-fresh");
+        let path = dir.join("catalog.json");
+        std::fs::write(
+            &path,
+            br#"{"vulnerabilities":[{"cveID":"CVE-2024-1111"},{"cveID":"CVE-2025-9999"}]}"#,
+        )
+        .unwrap();
+        // Generous TTL so the just-written file definitely qualifies.
+        let ids = read_cache(&path, 86_400).expect("fresh cache should yield ids");
+        assert!(ids.contains("CVE-2024-1111"));
+        assert!(ids.contains("CVE-2025-9999"));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn read_cache_treats_corrupt_body_as_miss() {
+        // A torn / partially-written cache file must NOT crash the run.
+        // Returning None routes the next call into a fresh fetch, which
+        // is exactly the right recovery — better than propagating a
+        // serde error up through `enrich` and breaking diffs.
+        let dir = tempdir_unique("read-corrupt");
+        let path = dir.join("catalog.json");
+        std::fs::write(&path, b"this is not json").unwrap();
+        assert!(read_cache(&path, 86_400).is_none());
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn write_cache_round_trips_through_read_cache() {
+        // The full atomic-write contract: `write_cache` writes via a
+        // `.tmp` sibling then renames, so there's never a torn file at
+        // `path` itself. After the write, `read_cache` must produce the
+        // same id set the body parses to. This is the load-bearing
+        // pair `load_or_fetch` relies on for cache hits.
+        let dir = tempdir_unique("roundtrip");
+        let path = dir.join("catalog.json");
+        let body = r#"{"vulnerabilities":[{"cveID":"CVE-2024-1111"},{"cveID":"CVE-2025-9999"}]}"#;
+        write_cache(&path, body);
+        assert!(path.exists());
+        let ids = read_cache(&path, 86_400).expect("written cache should be readable");
+        assert_eq!(ids.len(), 2);
+        assert!(ids.contains("CVE-2024-1111"));
+        assert!(ids.contains("CVE-2025-9999"));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn write_cache_creates_missing_parent_dirs() {
+        // KEV's first-ever cache write happens before the per-enricher
+        // subdir exists under `<XDG_CACHE>/bomdrift/`. `write_cache` must
+        // create it — otherwise the whole cache layer no-ops on a fresh
+        // user environment and every diff hits the network.
+        let dir = tempdir_unique("parent-dir");
+        let nested = dir.join("nope/still-nope/kev/catalog.json");
+        write_cache(&nested, r#"{"vulnerabilities":[]}"#);
+        assert!(
+            nested.exists(),
+            "write_cache should create nested parents on first write"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn cache_path_resolves_to_kev_subdir_when_cache_root_is_set() {
+        // `cache_path` returns `Some(<root>/kev/catalog.json)` when the
+        // platform cache root resolves; downstream code grabs it via
+        // `as_ref()` and passes it to read/write. Asserting only the
+        // suffix keeps the test platform-agnostic (Linux vs. macOS vs.
+        // CI sandbox locations all differ on root path).
+        let p = cache_path();
+        if let Some(p) = p {
+            let s = p.to_string_lossy();
+            assert!(
+                s.ends_with("kev/catalog.json") || s.ends_with("kev\\catalog.json"),
+                "expected suffix kev/catalog.json, got {s}"
+            );
+        }
+    }
 }

--- a/src/model/sbom.rs
+++ b/src/model/sbom.rs
@@ -40,3 +40,49 @@ impl Serialize for SbomFormat {
         serializer.serialize_str(self.as_str())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+    use super::*;
+
+    #[test]
+    fn as_str_round_trips_each_variant() {
+        // The string form is load-bearing for the SBOM diff comment header
+        // (`format = CycloneDX` in the metadata footer) and the SARIF run
+        // tool description. A typo in any branch silently mislabels every
+        // diff for that format.
+        assert_eq!(SbomFormat::CycloneDx.as_str(), "CycloneDX");
+        assert_eq!(SbomFormat::Spdx.as_str(), "SPDX");
+        assert_eq!(SbomFormat::Syft.as_str(), "Syft");
+    }
+
+    #[test]
+    fn display_matches_as_str_for_each_variant() {
+        // `format!` and `to_string()` go through Display::fmt, which must
+        // be byte-identical to as_str() — the diff renderer interleaves
+        // the two and a divergence would produce mixed-case labels in the
+        // same comment.
+        for f in [SbomFormat::CycloneDx, SbomFormat::Spdx, SbomFormat::Syft] {
+            assert_eq!(f.to_string(), f.as_str());
+            assert_eq!(format!("{f}"), f.as_str());
+        }
+    }
+
+    #[test]
+    fn serialize_emits_canonical_string_form() {
+        // JSON output of `bomdrift diff --output json` includes
+        // `"format": "CycloneDX"` in the SBOM block; downstream tooling
+        // pattern-matches on that value. Serialize MUST emit the same
+        // string as_str() returns, NOT the Rust enum-variant name
+        // (`"CycloneDx"`) or any debug form.
+        for (variant, expected) in [
+            (SbomFormat::CycloneDx, "\"CycloneDX\""),
+            (SbomFormat::Spdx, "\"SPDX\""),
+            (SbomFormat::Syft, "\"Syft\""),
+        ] {
+            let s = serde_json::to_string(&variant).unwrap();
+            assert_eq!(s, expected);
+        }
+    }
+}


### PR DESCRIPTION
## Why

Maintainer reviewed v0.9.8's lcov artifact and flagged three files with low coverage. Decomposing the data:

| File | Pre-fix lines | Pre-fix fns |
|---|---:|---:|
| `src/model/sbom.rs` | **0.0%** | **0.0%** |
| `src/enrich/kev.rs` | **39.6%** | **33.3%** |
| `src/enrich/osv.rs` | 58.0% | 71.0% |

This PR closes the first two. `osv.rs` is left as-is — its 58% is defensibly low because the uncovered surface is OSV's `/v1/querybatch` HTTP path (wide, would need a mock server in CI), and the pure-compute helpers are already covered.

## What

### `src/model/sbom.rs` — three tests, 0% → 100%

12 lines of pure match-arm impls (`SbomFormat::as_str`, `Display::fmt`, `Serialize::serialize`) with no I/O and no tests. The string output is load-bearing for:
- the SBOM diff comment's metadata footer
- the SARIF `run.tool` description
- the JSON output's `format` field

A typo in any branch silently mislabels every diff for that format, so pinning the canonical strings (`"CycloneDX"`, `"SPDX"`, `"Syft"`) across all three impls is high-leverage for a 10-line test cost.

### `src/enrich/kev.rs` — eight tests, ~40% → ~80% (estimated)

The file was *already* written for testability — the `enrich_with_url(e, url, timeout, ttl_hours)` injection-point signature plus pure-function `read_cache(path, ttl)` / `write_cache(path, body)` give clean test seams. Nothing was using them. Adding tests for:

- `enrich` and `enrich_with_ttl` short-circuit when `vulns` is empty (covers the public entry points through to `enrich_with_url`'s first branch)
- `enrich_with_url` with a refused-connect URL + 500ms timeout pins the best-effort contract: **network failure must NOT flag refs as KEV**. Uses port 1 (TCPMUX, never bound on GitHub-hosted runners) for a deterministic refuse-connect
- `read_cache`: missing file, fresh file within TTL, corrupt body — covers cache-hit and cache-miss recovery paths
- `write_cache`: round-trip through `read_cache` + parent-dir auto-creation. Pins the atomic-write-via-`.tmp`-rename contract that `load_or_fetch` relies on for cache hits
- `cache_path` suffix assertion, platform-agnostic for Linux/macOS/Windows runners

### Excluded: the strict TTL-expiry branch

`read_cache` uses `if age > ttl_secs { return None }` (strict greater-than). Forcing the expiry branch reliably needs either a 1+ second sleep (slows CI) or a `filetime` crate dep (out of scope). Single-line coverage gain doesn't justify either cost.

## Validation

- `cargo fmt --all --check` clean
- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo test --release`: **391 lib + 36 cli + 9 integration + 7 real-world + 1 doctest = 444 tests pass** (was 432 → +12 net)
- The CI coverage job's sticky comment on this PR is the dogfood — it should show the new file-level percentages once it lands.

## Note on what *isn't* in scope

This PR is purely additive — no production code touched. The asymmetry I noticed in `read_cache`'s expiry semantics (`age > ttl_secs` vs the more common `>=`) is intentionally left alone; changing prod behavior in a coverage-only PR would be a scope violation.
