### PR TITLE
ci: bump all workflow actions to Node 24-native majors + drop the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 mitigation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@1.88
         with:
           components: rustfmt
@@ -34,7 +34,7 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@1.88
         with:
           components: clippy
@@ -48,7 +48,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@1.88
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --all-features
@@ -64,7 +64,7 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@1.88
         with:
           components: llvm-tools-preview
@@ -74,7 +74,7 @@ jobs:
       - name: Run coverage
         run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
       - name: Upload lcov artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-lcov
           path: lcov.info
@@ -94,7 +94,7 @@ jobs:
           echo "total=$total" >> "$GITHUB_OUTPUT"
       - name: Post coverage summary as PR comment
         if: github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@v3
         with:
           header: bomdrift-coverage
           message: |
@@ -109,7 +109,7 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: rustsec/audit-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -117,7 +117,7 @@ jobs:
   deny:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: EmbarkStudios/cargo-deny-action@v2
         with:
           command: check
@@ -132,7 +132,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@1.88
       - uses: Swatinem/rust-cache@v2
       - run: cargo publish --dry-run --locked
@@ -141,7 +141,7 @@ jobs:
     name: shell-bridges (parser tests + regex sync)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: comment-suppress parser unit tests
         run: bash comment-suppress/test.sh
       - name: suppress-regex sync (shell ↔ bridge JS)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: rustsec/audit-check@v2
+      # Pinned to the post-v2.0.0 Node 24 commit (2026-03-20) until
+      # rustsec re-tags. The v2 / v2.0.0 tags still point at the
+      # September 2024 commit which targets Node 20 and would emit a
+      # deprecation warning.
+      - uses: rustsec/audit-check@858dc40f52ca2b8570b7a997c1c4e35c6fc9a432  # v2 Node 24
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,6 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -D warnings
-  # Opt every JavaScript-based action in this workflow into the Node.js 24
-  # runner ahead of GitHub's 2026-06-02 forced-default. Silences the
-  # "Node.js 20 actions are deprecated" warning the runner emits on every
-  # checkout / upload-artifact / sticky-pull-request-comment step. Remove
-  # once Node.js 24 is the default runtime.
-  # https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
   fmt:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,13 +14,6 @@ permissions:
   pages: write
   id-token: write
 
-env:
-  # Opt every JavaScript-based action in this workflow into the Node.js 24
-  # runner ahead of GitHub's 2026-06-02 forced-default. See ci.yml for the
-  # full rationale.
-  # https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-
 # Allow only one concurrent deployment, skipping in-flight runs but always
 # letting the most recent push reach production. Manually-dispatched runs
 # fall outside the cancel-in-progress to support targeted re-deploys.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.88
@@ -55,7 +55,7 @@ jobs:
         run: mdbook build docs
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/book
 
@@ -68,4 +68,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -17,13 +17,6 @@ on:
 permissions:
   contents: read
 
-env:
-  # Opt every JavaScript-based action in this workflow into the Node.js 24
-  # runner ahead of GitHub's 2026-06-02 forced-default. See ci.yml for the
-  # full rationale.
-  # https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-
 jobs:
   fuzz:
     runs-on: ubuntu-latest

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         target: [parse_cyclonedx, parse_spdx, parse_syft]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@nightly
       - uses: Swatinem/rust-cache@v2
         with:
@@ -49,7 +49,7 @@ jobs:
           cargo +nightly fuzz run ${{ matrix.target }} -- -max_total_time=$BUDGET
       - name: Upload artifacts on crash
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: fuzz-${{ matrix.target }}-artifacts
           path: fuzz/artifacts/

--- a/.github/workflows/rebuild-docker.yml
+++ b/.github/workflows/rebuild-docker.yml
@@ -109,7 +109,7 @@ jobs:
             ghcr.io/metbcy/bomdrift:latest
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v4.1.1
 
       - name: Sign image with cosign (keyless)
         env:

--- a/.github/workflows/rebuild-docker.yml
+++ b/.github/workflows/rebuild-docker.yml
@@ -29,9 +29,6 @@ permissions:
   id-token: write
   attestations: write
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-
 jobs:
   docker:
     name: docker (ghcr.io)

--- a/.github/workflows/rebuild-docker.yml
+++ b/.github/workflows/rebuild-docker.yml
@@ -43,7 +43,7 @@ jobs:
       # This decouples "the image's recipe" from "the binaries baked
       # into the image" — so a Dockerfile fix on main can rebuild
       # any past tag's image without rewriting that tag.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Compute version tag components
         id: ver
@@ -112,7 +112,7 @@ jobs:
             ghcr.io/metbcy/bomdrift:latest
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@v4
 
       - name: Sign image with cosign (keyless)
         env:
@@ -122,7 +122,7 @@ jobs:
             "ghcr.io/metbcy/bomdrift@${{ steps.build.outputs.digest }}"
 
       - name: Attest build provenance (image)
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@v4
         with:
           subject-name: ghcr.io/metbcy/bomdrift
           subject-digest: ${{ steps.build.outputs.digest }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
       tag: ${{ steps.tag.outputs.tag }}
       version: ${{ steps.tag.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Resolve tag
         id: tag
@@ -105,7 +105,7 @@ jobs:
             archive: zip
             use_cross: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.88
@@ -177,7 +177,7 @@ jobs:
           cat "${archive}.sha256"
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@v4
 
       - name: Sign archive with cosign (keyless)
         shell: bash
@@ -192,7 +192,7 @@ jobs:
             "$archive"
 
       - name: Upload artifact (per-target)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.stage.outputs.stem }}
           path: |
@@ -212,7 +212,7 @@ jobs:
       # <archive>` or `slsa-verifier verify-artifact --source-uri
       # github.com/Metbcy/bomdrift --source-tag <tag> <archive>`.
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@v4
         with:
           subject-path: dist/${{ steps.stage.outputs.stem }}.${{ matrix.archive }}
 
@@ -221,10 +221,10 @@ jobs:
     needs: [preflight, build]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Download all build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: dist
           merge-multiple: true
@@ -266,7 +266,7 @@ jobs:
           cat release-notes.md
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.preflight.outputs.tag }}
           name: ${{ needs.preflight.outputs.tag }}
@@ -294,7 +294,7 @@ jobs:
       packages: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Compute version tag components
         id: ver
@@ -308,7 +308,7 @@ jobs:
           echo "minor=v${major}.${minor}" >> "$GITHUB_OUTPUT"
 
       - name: Download all build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
           merge-multiple: true
@@ -352,7 +352,7 @@ jobs:
             ghcr.io/metbcy/bomdrift:latest
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@v4
 
       - name: Sign image with cosign (keyless)
         env:
@@ -365,7 +365,7 @@ jobs:
       # equivalent step on the per-target archives for the cosign-vs-SLSA
       # rationale.
       - name: Attest build provenance (image)
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@v4
         with:
           subject-name: ghcr.io/metbcy/bomdrift
           subject-digest: ${{ steps.build.outputs.digest }}
@@ -380,7 +380,7 @@ jobs:
     needs: [preflight, build, publish]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@1.88
       - uses: Swatinem/rust-cache@v2
       - name: cargo publish
@@ -400,7 +400,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Force-update major-version tag to current release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,11 +36,6 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
   RUST_BACKTRACE: 1
-  # Opt every JavaScript-based action in this workflow into the Node.js 24
-  # runner ahead of GitHub's 2026-06-02 forced-default. See ci.yml for the
-  # full rationale.
-  # https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
   preflight:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,7 +172,7 @@ jobs:
           cat "${archive}.sha256"
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v4.1.1
 
       - name: Sign archive with cosign (keyless)
         shell: bash
@@ -347,7 +347,7 @@ jobs:
             ghcr.io/metbcy/bomdrift:latest
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v4.1.1
 
       - name: Sign image with cosign (keyless)
         env:

--- a/.github/workflows/sbom-diff.yml
+++ b/.github/workflows/sbom-diff.yml
@@ -46,7 +46,7 @@ jobs:
         # something to point at. Consumers copying this workflow as
         # `uses: Metbcy/bomdrift@v1` don't need the checkout step (the
         # v0.5 zero-config flow handles before/after checkouts internally).
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run bomdrift (zero-config)
         uses: ./

--- a/.github/workflows/sbom-diff.yml
+++ b/.github/workflows/sbom-diff.yml
@@ -25,13 +25,6 @@ permissions:
   contents: read
   pull-requests: write       # to upsert the diff comment
 
-env:
-  # Opt every JavaScript-based action in this workflow into the Node.js 24
-  # runner ahead of GitHub's 2026-06-02 forced-default. See ci.yml for the
-  # full rationale.
-  # https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-
 concurrency:
   group: sbom-diff-${{ github.event.pull_request.number }}
   cancel-in-progress: true

--- a/action.yml
+++ b/action.yml
@@ -322,7 +322,7 @@ runs:
 
     - name: Install cosign (for release signature verification)
       if: inputs.verify-signatures == 'true'
-      uses: sigstore/cosign-installer@v4
+      uses: sigstore/cosign-installer@v4.1.1
 
     - name: Run bomdrift
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -296,7 +296,7 @@ runs:
 
     - name: Checkout after-ref (PR head, default)
       if: inputs.after-sbom == ''
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: ${{ inputs.after-ref }}
         path: __bomdrift_after
@@ -305,7 +305,7 @@ runs:
 
     - name: Checkout before-ref (PR base, default)
       if: inputs.before-sbom == ''
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: ${{ inputs.before-ref }}
         path: __bomdrift_before
@@ -322,7 +322,7 @@ runs:
 
     - name: Install cosign (for release signature verification)
       if: inputs.verify-signatures == 'true'
-      uses: sigstore/cosign-installer@v3
+      uses: sigstore/cosign-installer@v4
 
     - name: Run bomdrift
       shell: bash


### PR DESCRIPTION
## Why now

GitHub removes Node.js 20 from Actions runners on **2026-09-16** — that's ~5 months out. As of **2026-06-02** (33 days from this PR), Node 24 becomes the default runner runtime, and any action still targeting Node 20 in its `action.yml` will keep emitting deprecation warnings until the eventual hard-fail.

We added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'` in v0.9.8 as a temporary mitigation — it forced the runtime to Node 24, but the actions themselves still targeted Node 20. This PR fixes the underlying problem by upgrading the actions, then removes the mitigation.

## What's in this PR

**Commit 1** (`44327f0`) — bumps 9 actions across 6 workflow files to their latest Node 24-native majors. Several had drifted 2-4 majors behind:

| Action | Was | Now |
|---|---|---|
| `actions/checkout` | v4 | **v6** |
| `actions/upload-artifact` | v4 | **v7** |
| `actions/download-artifact` | v4 | **v8** |
| `actions/attest-build-provenance` | v2 | **v4** |
| `actions/deploy-pages` | v4 | **v5** |
| `actions/upload-pages-artifact` | v3 | **v5** |
| `marocchino/sticky-pull-request-comment` | v2 | **v3** |
| `sigstore/cosign-installer` | v3 | **v4** |
| `softprops/action-gh-release` | v2 | **v3** |

**Commit 2** (will land in this PR after commit 1's CI is green) — removes the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env var + its block-comment from all 6 workflows. **CI on commit 2 must show zero "Node.js 20" annotations** — that's the proof step.

## Breaking-change audit

None affect us:

- `upload-artifact@v7` — adds direct (unzipped) uploads via `archive: false`; default still zipped, we never set it.
- `download-artifact@v8` — errors on hash mismatches by default; matches our security posture.
- `checkout@v6` — stores creds under `$RUNNER_TEMP`; transparent unless using Docker container actions (we don't).
- `cosign-installer@v4` — required for installing Cosign 3.x; flag surface unchanged for our `sign --yes` + `verify-blob` usage.
- `attest-build-provenance@v4` — now a thin wrapper around `actions/attest`; existing usage stays valid per upstream notes.

## Verification

- ✅ All 6 workflow YAMLs still parse cleanly.
- ⏳ CI must pass on commit 1 (this commit).
- ⏳ CI must pass on commit 2 with **zero "Node.js 20" annotations** — added next.
- ⏳ Post-merge: trigger `rebuild-docker.yml` manually with `tag: v0.9.9` to smoke-test the docker action chain end-to-end.

## Coordination

Lands BEFORE the upcoming v0.9.10 file-splits release so they don't tangle on `release.yml`. v0.9.10's CHANGELOG will mention the env-var removal as a one-line bullet.

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot)