### PR TITLE
ci: bump docker/* actions to Node 24-native majors

### DIFF
--- a/.github/workflows/rebuild-docker.yml
+++ b/.github/workflows/rebuild-docker.yml
@@ -83,11 +83,11 @@ jobs:
             --wildcards '*/bomdrift'
           ls -la dist/linux-amd64 dist/linux-arm64
 
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -95,7 +95,7 @@ jobs:
 
       - name: Build and push multi-arch image
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -321,11 +321,11 @@ jobs:
             --wildcards '*/bomdrift'
           ls -la dist/linux-amd64 dist/linux-arm64
 
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -333,7 +333,7 @@ jobs:
 
       - name: Build and push multi-arch image
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Follow-up to PR #42. The rebuild-docker.yml smoke test surfaced four `docker/*` actions still on Node 20 (only used in release.yml + rebuild-docker.yml, so they didn't appear in PR #42's CI annotation scan).

**Bumps:**
- `docker/build-push-action` v6 → **v7**
- `docker/login-action` v3 → **v4**
- `docker/setup-buildx-action` v3 → **v4**
- `docker/setup-qemu-action` v3 → **v4**

All four require Actions Runner v2.327.1+ per their v7/v4 release notes; GitHub-hosted runners are well past. No flag-surface changes (same input keys: platforms, push, provenance, sbom, tags, registry, username, password, context).

After this lands, the next `rebuild-docker.yml` smoke run should show **zero** Node 20 annotations on the docker job — completing the Node 24 hygiene work.

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot)