### PR TITLE
ci(fuzz): drop --locked from cargo-fuzz install

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           workspaces: fuzz
       - name: Install cargo-fuzz
-        run: cargo install cargo-fuzz --locked
+        run: cargo install cargo-fuzz
       - name: Run fuzz target
         run: |
           BUDGET=60


### PR DESCRIPTION
cargo-fuzz v0.13.1's lockfile pins `rustix` v0.36.5 which uses reserved `rustc` attributes that newer nightly rejects. Dropping `--locked` lets Cargo resolve a compatible rustix version.

Fixes the weekly fuzz workflow failure: https://github.com/Metbcy/bomdrift/actions/runs/25621695066