### PR TITLE
test(vex): cover VexStatus::from_openvex affected/fixed arms

### DIFF
--- a/src/vex/mod.rs
+++ b/src/vex/mod.rs
@@ -526,6 +526,37 @@ mod tests {
         assert!(!populated.is_empty());
     }
 
+    /// Round-trip every OpenVEX status string through `from_openvex` and
+    /// back via `as_str`. Kills `delete match arm "affected"` /
+    /// `delete match arm "fixed"` mutants at mod.rs:74-75 (the previous
+    /// suite only exercised "not_affected" and "under_investigation"
+    /// indirectly, leaving the affected/fixed arms unverified).
+    #[test]
+    fn vex_status_from_openvex_round_trips_all_arms() {
+        let cases = [
+            ("not_affected", VexStatus::NotAffected),
+            ("affected", VexStatus::Affected),
+            ("fixed", VexStatus::Fixed),
+            ("under_investigation", VexStatus::UnderInvestigation),
+        ];
+        for (s, expected) in cases {
+            let parsed =
+                VexStatus::from_openvex(s).unwrap_or_else(|| panic!("expected Some for {s:?}"));
+            assert_eq!(parsed, expected, "from_openvex({s:?})");
+            assert_eq!(parsed.as_str(), s, "as_str round-trip for {expected:?}");
+        }
+    }
+
+    /// Unknown / capitalized / empty OpenVEX status strings must return
+    /// None — not silently fall through to a wrong arm.
+    #[test]
+    fn vex_status_from_openvex_rejects_unknown_strings() {
+        assert_eq!(VexStatus::from_openvex(""), None);
+        assert_eq!(VexStatus::from_openvex("Affected"), None);
+        assert_eq!(VexStatus::from_openvex("not affected"), None);
+        assert_eq!(VexStatus::from_openvex("exploitable"), None);
+    }
+
     /// `detect_format` second arm requires BOTH `bomFormat == "CycloneDX"`
     /// AND a `vulnerabilities` array. Kills the `&& -> ||` mutant at line
     /// 162: with `||`, a doc that has only `bomFormat` (a regular CycloneDX


### PR DESCRIPTION
Closes the last two cargo-mutants survivors from #35.

## Surviving mutants killed

```
MISSED   src/vex/mod.rs:74: delete match arm "affected" in VexStatus::from_openvex
MISSED   src/vex/mod.rs:75: delete match arm "fixed"    in VexStatus::from_openvex
```

The prior suite covered `not_affected` / `under_investigation` indirectly through end-to-end fixtures, but never asserted that `from_openvex("affected")` / `from_openvex("fixed")` mapped to the right variants — so deleting either arm still let every test pass.

## What this adds

- `vex_status_from_openvex_round_trips_all_arms` — table-driven, asserts `from_openvex(s) == expected` **and** `as_str()` round-trips back to `s` for all four OpenVEX statuses.
- `vex_status_from_openvex_rejects_unknown_strings` — empty string, capitalized `Affected`, the CycloneDX-flavored `exploitable`, and a space-separated variant all return `None` (no silent fallthrough).

## Verification

- `cargo test --release --lib vex_status_from_openvex`: 2 passed
- Full lib suite: 404 passed (was 402)
- `RUSTFLAGS="-D warnings" cargo build --all-targets --all-features`: clean
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo fmt --check`: clean

After this lands, `src/vex/**` should be at **100% kill rate on viable mutants** (82 caught / 0 missed / 15 unviable), up from 97.6% after #51 + #52.