### PR TITLE
feat(maintainer-age): extend signal to GitLab and Codeberg hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ With network access, an additional Vulnerabilities section lists each advisory I
 - **EPSS** (FIRST.org Exploit Prediction Scoring System) per CVE, with `--fail-on-epss <0.0–1.0>` threshold gating (v0.8).
 - **CISA KEV** known-exploited flag per advisory, with `--fail-on kev` gating (v0.8).
 - **Typosquat detection** across **npm**, **PyPI**, **Cargo**, **Maven**, **Go**, **RubyGems**, **NuGet**, and **Composer**. Jaro-Winkler + suffix-containment boost (Levenshtein for Maven artifactIds, last-path-segment match for Go, package-portion match for Composer). Threshold tunable via `--typosquat-similarity-threshold` (v0.9.6). Refreshable via `bomdrift refresh-typosquat`.
-- **Maintainer-age signal** — top GitHub contributor's first commit younger than `--young-maintainer-days` (default 90; tunable v0.9.6). The xz / Jia Tan pattern. Honors `GITHUB_TOKEN`, skipped on repos with > 50 contributors.
+- **Maintainer-age signal** — top contributor's first commit younger than `--young-maintainer-days` (default 90; tunable v0.9.6). The xz / Jia Tan pattern. Covers GitHub (`GITHUB_TOKEN`), GitLab (`GITLAB_TOKEN`), and Codeberg (`CODEBERG_TOKEN`). Skipped on repos with > 50 contributors.
 - **Multi-major version jumps** (≥ 2 majors) — pure compute, correlates with takeover swaps and namespace reuse.
 - **Registry-metadata enrichers (npm / PyPI / crates.io)** — recently-published, deprecated, maintainer-set-changed (npm-only) (v0.9). Threshold via `--recently-published-days`, opt-out via `--no-registry`.
 - **License policy** — `--allow-licenses` / `--deny-licenses` with SPDX expression evaluation (v0.9), plus per-exception `--allow-exception` / `--deny-exception` for `WITH`-clause granularity (v0.9.5).

--- a/docs/src/enrichers/maintainer-age.md
+++ b/docs/src/enrichers/maintainer-age.md
@@ -1,7 +1,7 @@
 # Maintainer age signal
 
-Flag newly added GitHub-hosted dependencies whose top contributor's first
-commit is suspiciously recent. **The xz/Jia Tan pattern.**
+Flag newly added dependencies (GitHub, GitLab, Codeberg) whose top
+contributor's first commit is suspiciously recent. **The xz/Jia Tan pattern.**
 
 ## Why it matters
 
@@ -31,34 +31,42 @@ or `[diff] young_maintainer_days = <N>` (v0.9.6+); see
 
 ## How it works
 
-For each `cs.added` component with a GitHub `source_url`:
+For each `cs.added` component with a `source_url` on a supported host:
+
+### GitHub
 
 1. **GET `/repos/{owner}/{repo}/contributors?per_page=1`** — top
    contributor login.
-2. **GET `/repos/{owner}/{repo}/contributors`** to count contributors.
-   **Skip if > 50** — "top contributor joined recently" loses meaning
-   when 200 people have committed (Linux, Kubernetes, React, etc.).
-3. **GET `/repos/{owner}/{repo}/commits?author=<login>&per_page=1`** to
-   find the most recent commit by that author.
-4. **Paginate to the last page** to find their *first* commit. The
-   "first commit by author" pagination trick is slow on prolific
-   contributors (last page can be page 50+) but is correct without
-   needing the GraphQL API.
-5. **Compare against the SBOM-after timestamp** (or `clock::now()` when
-   the SBOM lacks a metadata timestamp). Flag when the first commit is
-   younger than `YOUNG_MAINTAINER_DAYS` (default 90; tunable via
-   `--young-maintainer-days <N>` in v0.9.6+).
+2. **GET `/repos/{owner}/{repo}/contributors?per_page=1&anon=true`** —
+   contributor count from Link `rel="last"` page number. **Skip if > 50.**
+3. **GET `/repos/{owner}/{repo}/commits?author=<login>&per_page=1`** —
+   paginate to last page for the author's oldest commit (`commit.author.date`).
+
+### GitLab
+
+1. **GET `/api/v4/projects/{url-encoded}/repository/contributors?order_by=commits&sort=desc&per_page=1`** —
+   top contributor name (GitLab identifies contributors by author name, not
+   login) and total count via `X-Total` header. **Skip if > 50.**
+2. **GET `.../commits?author=<name>&per_page=1`** — paginate to last page
+   via Link header for the author's oldest commit (`authored_date`).
+
+### Codeberg
+
+URL parsing and dispatch are implemented. The per-author first-commit
+lookup is stubbed pending verification of the Forgejo v1.20+ API shape;
+Codeberg components produce no finding in this release.
 
 ## Skipped cases
 
 - Components without a `source_url` (CycloneDX `externalReferences`
-  with no `vcs` entry, etc.) — silently skipped.
-- Non-`github.com` source URLs — silently skipped (GitLab / Codeberg
-  / etc. would need per-host clients; out of scope for v0).
-- Repositories with **> 50 contributors** — skipped because the "top
+  with no `vcs` entry, etc.) -- silently skipped.
+- Source URLs not from `github.com`, `gitlab.com`, or `codeberg.org` --
+  silently skipped.
+- Repositories with **> 50 contributors** -- skipped because the "top
   contributor's first commit" loses meaning on monorepos and
   multi-vendor projects.
-- Repositories returning 404 or 403 — skipped, warned once.
+- Repositories returning 404, 401, or 403 -- skipped silently (private
+  repo or missing token).
 
 Per-repo results are cached within a single bomdrift run so repeated
 `cs.added` entries from the same project don't re-issue the same three
@@ -67,13 +75,14 @@ requests.
 ## Network behavior
 
 - **Per-request timeout**: 15 seconds.
-- **`GITHUB_TOKEN` honored**: bumps the unauthenticated 60/hr cap to
-  the authenticated 5000/hr cap. Without a token, large diffs (~30+
-  added GitHub deps) will hit rate-limiting; surface as a warning,
-  partial results render, exit code stays 0.
+- **Token env vars**: `GITHUB_TOKEN` (Bearer), `GITLAB_TOKEN`
+  (PRIVATE-TOKEN), `CODEBERG_TOKEN` (Authorization: token). All optional;
+  missing token means unauthenticated requests (fine for low volume).
+  `GITHUB_TOKEN` bumps the unauthenticated 60/hr cap to 5000/hr.
 - **No `octocrab`**: the `octocrab` crate would pull in tokio + ~70
   transitive crates. Hand-rolled `ureq` GETs + a 25-line ISO-8601
-  parser keep the bomdrift binary under our 5 MB target.
+  parser keep the bomdrift binary under our 5 MB target. Same
+  constraint applies to the GitLab and Codeberg paths.
 
 ## Calibration
 
@@ -98,13 +107,12 @@ maintainer-age|<purl>|<days_since_first_commit>|90
 
 ## Disabling
 
-`--no-maintainer-age` skips the entire enricher (no GitHub API calls).
-Required for:
+`--no-maintainer-age` skips the entire enricher (no GitHub, GitLab, or
+Codeberg API calls). Required for:
 
 - Offline runs and tests.
-- CI environments where `GITHUB_TOKEN` is unset and the
-  unauthenticated rate limit (60/hr) is too low for the diff being
-  analyzed.
+- CI environments where tokens are unset and unauthenticated rate
+  limits are too low for the diff being analyzed.
 - Smoke tests of the deterministic offline signals.
 
 ```bash

--- a/src/enrich/maintainer.rs
+++ b/src/enrich/maintainer.rs
@@ -1,21 +1,22 @@
-//! Maintainer-age enrichment: flag newly added GitHub-hosted dependencies whose
-//! top contributor's first commit is suspiciously recent.
+//! Maintainer-age enrichment: flag newly added dependencies hosted on GitHub,
+//! GitLab, or Codeberg whose top contributor's first commit is suspiciously
+//! recent.
 //!
 //! ## The signal
 //!
 //! The xz/`liblzma` backdoor of 2024 (CVE-2024-3094) was authored by a GitHub
 //! identity ("Jia Tan") that started contributing two years before introducing
-//! the malicious payload. The pattern — a brand-new account becoming the de
-//! facto sole maintainer of a low-traffic but widely-depended-upon package —
+//! the malicious payload. The pattern -- a brand-new account becoming the de
+//! facto sole maintainer of a low-traffic but widely-depended-upon package --
 //! is a leading indicator of long-game supply-chain takeovers. We can't catch
 //! Jia Tan in retrospect, but we can flag the next one earlier in their arc by
-//! surfacing "this package's top contributor opened their first PR less than
+//! surfacing "this package's top contributor opened their first commit less than
 //! 90 days ago" at the moment a new dep is added.
 //!
 //! ## Threshold
 //!
 //! 90 days is intentionally aggressive. Most legitimate new packages will trip
-//! this on initial introduction; that's fine — a human reviewer can dismiss
+//! this on initial introduction; that's fine -- a human reviewer can dismiss
 //! "the package is brand-new and the author is its only maintainer" trivially.
 //! The expensive miss is the **silent takeover** of an existing package by a
 //! recently-arrived contributor, which is what 90-day captures. Tune later if
@@ -27,31 +28,31 @@
 //! three GET requests. `chrono` similarly bloats the dep tree for parsing one
 //! ISO-8601 timestamp shape (GitHub always emits the canonical
 //! `YYYY-MM-DDTHH:MM:SSZ`). Hand-rolled `ureq` calls and a 25-line ISO-8601
-//! parser keep the binary under our 5 MB target.
+//! parser keep the binary under our 5 MB target. The same constraint applies
+//! to GitLab and Codeberg; no new heavyweight dependencies are added.
 //!
 //! ## Network behavior
 //!
 //! Best-effort, mirrors the OSV enricher: per-request timeout 15 seconds,
-//! errors surface as warnings on stderr, the diff still renders. The
-//! `GITHUB_TOKEN` env var raises the rate limit from 60/hr to 5000/hr; without
-//! it we hit the unauthenticated cap fast. On a 403 + `X-RateLimit-Remaining: 0`
-//! we emit one warning and return whatever was already collected — no crash,
-//! no silent data loss.
+//! errors surface as warnings on stderr, the diff still renders. Token env
+//! vars raise rate limits: `GITHUB_TOKEN` (Bearer, GitHub REST), `GITLAB_TOKEN`
+//! (PRIVATE-TOKEN header, GitLab v4), `CODEBERG_TOKEN` (Authorization: token,
+//! Gitea v1). All three are optional; absent means unauthenticated requests,
+//! fine for low volume.
 //!
 //! ## Skipped cases
 //!
 //! - Components without a `source_url` (CycloneDX `externalReferences[type=vcs]`
-//!   absent, etc.) — silently skipped.
-//! - Non-`github.com` source URLs — skipped (GitLab / Codeberg / etc. would need
-//!   per-host clients; out of scope for v0).
-//! - Repositories with > 50 contributors — skipped because the "top
+//!   absent, etc.) -- silently skipped.
+//! - Source URLs not matching github.com, gitlab.com, or codeberg.org --
+//!   silently skipped.
+//! - Repositories with > 50 contributors -- skipped because the "top
 //!   contributor's first commit" loses meaning on monorepos and multi-vendor
 //!   projects (Linux, Kubernetes, React).
 //! - Per-repo results are cached within a single bomdrift run so repeated
 //!   `cs.added` entries from the same project don't multiply HTTP requests.
 //!
-//! Always informational severity — never trips fail-on (which doesn't exist
-//! yet anyway).
+//! Always informational severity -- never trips fail-on.
 
 use std::collections::HashMap;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -63,6 +64,7 @@ use crate::diff::ChangeSet;
 use crate::model::Component;
 
 const GITHUB_API_BASE: &str = "https://api.github.com";
+const GITLAB_API_BASE: &str = "https://gitlab.com/api/v4";
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(15);
 const USER_AGENT: &str = concat!("bomdrift/", env!("CARGO_PKG_VERSION"));
 
@@ -74,14 +76,35 @@ const MAX_CONTRIBUTORS_FOR_SIGNAL: u64 = 50;
 /// finding. See module docs for rationale.
 pub const YOUNG_MAINTAINER_DAYS: i64 = 90;
 
+/// The forge host where a dependency's source repository lives.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Host {
+    Github,
+    Gitlab,
+    Codeberg,
+}
+
+impl Host {
+    fn label(self) -> &'static str {
+        match self {
+            Host::Github => "GitHub",
+            Host::Gitlab => "GitLab",
+            Host::Codeberg => "Codeberg",
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct MaintainerAgeFinding {
     pub component: Component,
     pub top_contributor: String,
-    /// ISO-8601 string as returned by GitHub (`2026-01-15T12:34:56Z`). Stored
+    /// ISO-8601 string as returned by the forge (`2026-01-15T12:34:56Z`). Stored
     /// verbatim so renderers can show it without re-formatting.
     pub first_commit_at: String,
     pub days_old: i64,
+    /// Which forge host the component's source URL belongs to.
+    pub host: Host,
 }
 
 /// Cached per-repo lookup result, so multiple `cs.added` entries from the same
@@ -90,7 +113,7 @@ pub struct MaintainerAgeFinding {
 struct MaintainerInfo {
     /// `Some(...)` when the repo passed all filters and we got a date back.
     /// `None` when the repo was skipped (too many contributors, no commits,
-    /// not-found, etc.) — cached so we don't retry.
+    /// not-found, etc.) -- cached so we don't retry.
     finding: Option<(String, String, i64)>,
 }
 
@@ -98,6 +121,9 @@ pub fn enrich(cs: &ChangeSet) -> Result<Vec<MaintainerAgeFinding>> {
     enrich_with(cs, GITHUB_API_BASE, DEFAULT_TIMEOUT, None)
 }
 
+/// GitHub-only enrichment. Accepts a `base_url` override so tests can point at
+/// an unreachable address and confirm that non-GitHub URLs short-circuit before
+/// any HTTP is issued. For multi-host production use, call `enrich_with_hosts`.
 pub fn enrich_with(
     cs: &ChangeSet,
     base_url: &str,
@@ -131,7 +157,8 @@ pub fn enrich_with(
         let info = if let Some(cached) = cache.get(&key) {
             cached.clone()
         } else {
-            let lookup = lookup_repo(&agent, base_url, &owner, &repo, token.as_deref(), now_secs);
+            let lookup =
+                lookup_github_repo(&agent, base_url, &owner, &repo, token.as_deref(), now_secs);
             match lookup {
                 Ok(info) => {
                     cache.insert(key.clone(), info.clone());
@@ -157,6 +184,123 @@ pub fn enrich_with(
                 top_contributor: login,
                 first_commit_at: date,
                 days_old: days,
+                host: Host::Github,
+            });
+        }
+    }
+
+    Ok(out)
+}
+
+/// Multi-host enrichment covering GitHub, GitLab, and Codeberg. This is the
+/// production entry point used by `run.rs`. The `github_base_url` parameter
+/// mirrors the `base_url` parameter of `enrich_with` so existing call sites
+/// require only a rename.
+pub fn enrich_with_hosts(
+    cs: &ChangeSet,
+    github_base_url: &str,
+    timeout: Duration,
+    young_maintainer_days: Option<i64>,
+) -> Result<Vec<MaintainerAgeFinding>> {
+    let threshold = young_maintainer_days.unwrap_or(YOUNG_MAINTAINER_DAYS);
+    if cs.added.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let github_token = std::env::var("GITHUB_TOKEN").ok();
+    let gitlab_token = std::env::var("GITLAB_TOKEN").ok();
+    let codeberg_token = std::env::var("CODEBERG_TOKEN").ok();
+    let agent = ureq::AgentBuilder::new().timeout(timeout).build();
+    let mut cache: HashMap<String, MaintainerInfo> = HashMap::new();
+    let mut out: Vec<MaintainerAgeFinding> = Vec::new();
+    // Per-host rate-limit flags: [github, gitlab, codeberg].
+    let mut rate_limited = [false; 3];
+
+    let now_secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+
+    for comp in &cs.added {
+        let Some(url) = comp.source_url.as_deref() else {
+            continue;
+        };
+
+        let (host, owner, repo) = if let Some((o, r)) = parse_github_repo(url) {
+            (Host::Github, o, r)
+        } else if let Some((o, r)) = parse_gitlab_repo(url) {
+            (Host::Gitlab, o, r)
+        } else if let Some((o, r)) = parse_codeberg_repo(url) {
+            (Host::Codeberg, o, r)
+        } else {
+            continue;
+        };
+
+        let host_idx = match host {
+            Host::Github => 0,
+            Host::Gitlab => 1,
+            Host::Codeberg => 2,
+        };
+        if rate_limited[host_idx] {
+            continue;
+        }
+
+        let host_str = match host {
+            Host::Github => "github",
+            Host::Gitlab => "gitlab",
+            Host::Codeberg => "codeberg",
+        };
+        let key = format!("{host_str}/{owner}/{repo}");
+
+        let info = if let Some(cached) = cache.get(&key) {
+            cached.clone()
+        } else {
+            let lookup = match host {
+                Host::Github => lookup_github_repo(
+                    &agent,
+                    github_base_url,
+                    &owner,
+                    &repo,
+                    github_token.as_deref(),
+                    now_secs,
+                ),
+                Host::Gitlab => {
+                    lookup_gitlab_repo(&agent, &owner, &repo, gitlab_token.as_deref(), now_secs)
+                }
+                Host::Codeberg => {
+                    lookup_codeberg_repo(&agent, &owner, &repo, codeberg_token.as_deref(), now_secs)
+                }
+            };
+            match lookup {
+                Ok(info) => {
+                    cache.insert(key.clone(), info.clone());
+                    info
+                }
+                Err(LookupError::RateLimited) => {
+                    rate_limited[host_idx] = true;
+                    eprintln!(
+                        "warning: {} rate limit exhausted, skipping remaining {} maintainer-age lookups",
+                        host.label(),
+                        host.label(),
+                    );
+                    cache.insert(key, MaintainerInfo { finding: None });
+                    continue;
+                }
+                Err(LookupError::Other(err)) => {
+                    return Err(err);
+                }
+            }
+        };
+
+        if let Some((login, date, days)) = info.finding
+            && days < threshold
+        {
+            out.push(MaintainerAgeFinding {
+                component: comp.clone(),
+                top_contributor: login,
+                first_commit_at: date,
+                days_old: days,
+                host,
             });
         }
     }
@@ -169,10 +313,12 @@ enum LookupError {
     Other(anyhow::Error),
 }
 
-/// Resolve a single `owner/repo`. Returns the maintainer's login + first commit
-/// date + days-old when the repo is in scope, or `MaintainerInfo { finding: None }`
-/// when it's been deliberately skipped (monorepo, no commits, missing data).
-fn lookup_repo(
+// ---- GitHub ----
+
+/// Resolve a single `owner/repo` on GitHub. Returns the maintainer's login +
+/// first commit date + days-old when the repo is in scope, or
+/// `MaintainerInfo { finding: None }` when deliberately skipped.
+fn lookup_github_repo(
     agent: &ureq::Agent,
     base_url: &str,
     owner: &str,
@@ -285,6 +431,202 @@ fn github_get(
     }
 }
 
+// ---- GitLab ----
+
+/// Resolve a single `owner/repo` on GitLab using the v4 REST API.
+/// Uses `X-Total` header for contributor count (no Link-header parsing needed).
+/// Author names (not logins) are stored; GitLab contributors are identified by
+/// commit author name/email, not a username.
+fn lookup_gitlab_repo(
+    agent: &ureq::Agent,
+    owner: &str,
+    repo: &str,
+    token: Option<&str>,
+    now_secs: i64,
+) -> std::result::Result<MaintainerInfo, LookupError> {
+    let project_id = percent_encode(&format!("{owner}/{repo}"));
+
+    // Steps 1+2 combined: per_page=1 returns the top contributor by commit
+    // count, and GitLab includes X-Total (total contributor count) on any
+    // paginated response regardless of per_page.
+    let top_url = format!(
+        "{GITLAB_API_BASE}/projects/{project_id}/repository/contributors\
+         ?order_by=commits&sort=desc&per_page=1"
+    );
+    let top_resp = gitlab_get(agent, &top_url, token)?;
+
+    let contributor_count = top_resp.x_total.unwrap_or(u64::MAX);
+    if contributor_count > MAX_CONTRIBUTORS_FOR_SIGNAL {
+        return Ok(MaintainerInfo { finding: None });
+    }
+
+    let top_name = parse_gitlab_top_contributor_name(&top_resp.body)
+        .context("parsing GitLab top-contributor response")
+        .map_err(LookupError::Other)?;
+    let Some(top_name) = top_name else {
+        return Ok(MaintainerInfo { finding: None });
+    };
+
+    // Step 3: first commit by that author. GitLab's commits endpoint accepts
+    // ?author=<name> to filter by author name. Newest-first; paginate to last
+    // page for the oldest commit, same Link-header trick as GitHub.
+    let author_enc = percent_encode(&top_name);
+    let commits_first_url = format!(
+        "{GITLAB_API_BASE}/projects/{project_id}/repository/commits\
+         ?author={author_enc}&per_page=1"
+    );
+    let commits_first = gitlab_get(agent, &commits_first_url, token)?;
+    let last_page = parse_link_last_page(commits_first.link_header.as_deref());
+
+    let oldest_body = match last_page {
+        Some(page) if page > 1 => {
+            let last_url = format!(
+                "{GITLAB_API_BASE}/projects/{project_id}/repository/commits\
+                 ?author={author_enc}&per_page=1&page={page}"
+            );
+            gitlab_get(agent, &last_url, token)?.body
+        }
+        _ => commits_first.body,
+    };
+
+    let date_str = match parse_gitlab_first_commit_date(&oldest_body) {
+        Ok(Some(d)) => d,
+        Ok(None) => return Ok(MaintainerInfo { finding: None }),
+        Err(e) => return Err(LookupError::Other(e)),
+    };
+
+    // GitLab timestamps vary: "2024-04-15T12:34:56.000+00:00", "...Z", etc.
+    // Normalize to YYYY-MM-DDTHH:MM:SSZ for our parser. Day-granularity
+    // calculations absorb the small UTC-offset error.
+    let normalized = match normalize_iso8601(&date_str) {
+        Some(d) => d,
+        None => return Ok(MaintainerInfo { finding: None }),
+    };
+
+    let Some(commit_secs) = iso8601_to_unix_seconds(&normalized) else {
+        return Ok(MaintainerInfo { finding: None });
+    };
+    let days = (now_secs - commit_secs) / 86_400;
+
+    Ok(MaintainerInfo {
+        finding: Some((top_name, normalized, days)),
+    })
+}
+
+struct GitlabResponse {
+    body: String,
+    link_header: Option<String>,
+    /// GitLab includes the total item count in `X-Total` on every paginated
+    /// response, regardless of `per_page`. Absent when the total exceeds
+    /// GitLab's configured limit (very large repos).
+    x_total: Option<u64>,
+}
+
+fn gitlab_get(
+    agent: &ureq::Agent,
+    url: &str,
+    token: Option<&str>,
+) -> std::result::Result<GitlabResponse, LookupError> {
+    let mut req = agent.get(url).set("user-agent", USER_AGENT);
+    if let Some(t) = token {
+        req = req.set("PRIVATE-TOKEN", t);
+    }
+    match req.call() {
+        Ok(resp) => {
+            let link_header = resp.header("link").map(str::to_string);
+            let x_total = resp.header("x-total").and_then(|v| v.parse::<u64>().ok());
+            let body = resp
+                .into_string()
+                .context("reading GitLab response body")
+                .map_err(LookupError::Other)?;
+            Ok(GitlabResponse {
+                body,
+                link_header,
+                x_total,
+            })
+        }
+        Err(ureq::Error::Status(429, _)) => Err(LookupError::RateLimited),
+        Err(ureq::Error::Status(401 | 403 | 404, _)) => {
+            // 401/403: repo is private or token missing; skip silently.
+            // 404: repo gone or moved; skip.
+            Ok(GitlabResponse {
+                body: "[]".to_string(),
+                link_header: None,
+                x_total: Some(0),
+            })
+        }
+        Err(e) => Err(LookupError::Other(
+            anyhow::Error::new(e).context(format!("GET {url} failed")),
+        )),
+    }
+}
+
+// ---- Codeberg ----
+
+/// Stub: Codeberg (Forgejo/Gitea v1) URL parsing and Host dispatch are wired,
+/// but the per-author first-commit lookup is not yet implemented. Gitea's
+/// commits endpoint gained reliable `?author=` filtering in v1.20; Codeberg's
+/// exact API version and behavior need verification before shipping. Returns
+/// no finding so the enricher stays clean rather than guessing.
+///
+/// TODO: implement lookup once Forgejo v1.20+ per-author commit filter is
+/// confirmed. API base would be https://codeberg.org/api/v1.
+fn lookup_codeberg_repo(
+    _agent: &ureq::Agent,
+    _owner: &str,
+    _repo: &str,
+    _token: Option<&str>,
+    _now_secs: i64,
+) -> std::result::Result<MaintainerInfo, LookupError> {
+    Ok(MaintainerInfo { finding: None })
+}
+
+// ---- shared utilities ----
+
+/// Percent-encode a string for use in URL path segments or query values.
+/// Unreserved characters (RFC 3986) are passed through; everything else,
+/// including `/`, is encoded as `%XX`.
+fn percent_encode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 10);
+    for &byte in s.as_bytes() {
+        if matches!(byte, b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~') {
+            out.push(byte as char);
+        } else {
+            out.push('%');
+            out.push(b"0123456789ABCDEF"[(byte >> 4) as usize] as char);
+            out.push(b"0123456789ABCDEF"[(byte & 0xF) as usize] as char);
+        }
+    }
+    out
+}
+
+/// Normalize an ISO-8601 timestamp to `YYYY-MM-DDTHH:MM:SSZ` for our parser.
+/// Strips fractional seconds and timezone offset, keeping only the first 19
+/// characters. Safe for day-granularity age calculations where an hour of
+/// timezone drift does not affect the 90-day threshold.
+fn normalize_iso8601(s: &str) -> Option<String> {
+    let bytes = s.as_bytes();
+    if bytes.len() < 19 {
+        return None;
+    }
+    // Validate the structural separators at fixed positions.
+    if bytes[4] != b'-'
+        || bytes[7] != b'-'
+        || bytes[10] != b'T'
+        || bytes[13] != b':'
+        || bytes[16] != b':'
+    {
+        return None;
+    }
+    // Defend against malformed input with a multi-byte UTF-8 char straddling
+    // byte 19 (the slice point). The structural-separator checks above only
+    // pin 5 of the first 19 bytes; the rest could in principle be anything.
+    if !s.is_char_boundary(19) {
+        return None;
+    }
+    Some(format!("{}Z", &s[..19]))
+}
+
 /// Extract `(owner, repo)` from a GitHub source URL. Returns `None` for
 /// non-GitHub hosts. Strips a trailing `.git` suffix and any trailing path.
 pub(crate) fn parse_github_repo(url: &str) -> Option<(String, String)> {
@@ -303,6 +645,76 @@ pub(crate) fn parse_github_repo(url: &str) -> Option<(String, String)> {
         .strip_prefix("github.com/")
         .or_else(|| stripped.strip_prefix("github.com:"))
         .or_else(|| stripped.strip_prefix("www.github.com/"))?;
+
+    let mut parts = rest.split('/');
+    let owner = parts.next()?.to_string();
+    let repo_raw = parts.next()?;
+    let repo = repo_raw
+        .split(['#', '?'])
+        .next()
+        .unwrap_or(repo_raw)
+        .trim_end_matches('/')
+        .trim_end_matches(".git")
+        .to_string();
+
+    if owner.is_empty() || repo.is_empty() {
+        return None;
+    }
+    Some((owner, repo))
+}
+
+/// Extract `(owner, repo)` from a GitLab source URL. Returns `None` for
+/// non-GitLab hosts. Strips a trailing `.git` suffix and any trailing path.
+///
+/// Note: GitLab subgroup URLs (`gitlab.com/group/subgroup/repo`) are not
+/// supported; the parser returns the first two path segments. Such URLs will
+/// produce a 404 on the API call and be silently skipped.
+pub(crate) fn parse_gitlab_repo(url: &str) -> Option<(String, String)> {
+    let stripped = url
+        .trim()
+        .trim_start_matches("git+")
+        .trim_start_matches("https://")
+        .trim_start_matches("http://")
+        .trim_start_matches("git://")
+        .trim_start_matches("ssh://")
+        .trim_start_matches("git@");
+
+    let rest = stripped
+        .strip_prefix("gitlab.com/")
+        .or_else(|| stripped.strip_prefix("gitlab.com:"))?;
+
+    let mut parts = rest.split('/');
+    let owner = parts.next()?.to_string();
+    let repo_raw = parts.next()?;
+    let repo = repo_raw
+        .split(['#', '?'])
+        .next()
+        .unwrap_or(repo_raw)
+        .trim_end_matches('/')
+        .trim_end_matches(".git")
+        .to_string();
+
+    if owner.is_empty() || repo.is_empty() {
+        return None;
+    }
+    Some((owner, repo))
+}
+
+/// Extract `(owner, repo)` from a Codeberg source URL. Returns `None` for
+/// non-Codeberg hosts. Strips a trailing `.git` suffix and any trailing path.
+pub(crate) fn parse_codeberg_repo(url: &str) -> Option<(String, String)> {
+    let stripped = url
+        .trim()
+        .trim_start_matches("git+")
+        .trim_start_matches("https://")
+        .trim_start_matches("http://")
+        .trim_start_matches("git://")
+        .trim_start_matches("ssh://")
+        .trim_start_matches("git@");
+
+    let rest = stripped
+        .strip_prefix("codeberg.org/")
+        .or_else(|| stripped.strip_prefix("codeberg.org:"))?;
 
     let mut parts = rest.split('/');
     let owner = parts.next()?.to_string();
@@ -346,7 +758,7 @@ pub(crate) fn parse_link_last_page(link: Option<&str>) -> Option<u64> {
 }
 
 /// Parse `YYYY-MM-DDTHH:MM:SSZ` (GitHub's canonical timestamp form) into Unix
-/// seconds. Returns `None` for any deviation from that exact shape — we do not
+/// seconds. Returns `None` for any deviation from that exact shape -- we do not
 /// try to be a full ISO-8601 parser.
 pub(crate) fn iso8601_to_unix_seconds(s: &str) -> Option<i64> {
     let bytes = s.as_bytes();
@@ -380,7 +792,7 @@ pub(crate) fn iso8601_to_unix_seconds(s: &str) -> Option<i64> {
 }
 
 /// Days since 1970-01-01 for a proleptic Gregorian (year, month, day). Howard
-/// Hinnant's `days_from_civil` algorithm — exact, branch-free, ~10 lines.
+/// Hinnant's `days_from_civil` algorithm -- exact, branch-free, ~10 lines.
 /// See <https://howardhinnant.github.io/date_algorithms.html>.
 fn days_from_civil(y: i64, m: i64, d: i64) -> i64 {
     let y = if m <= 2 { y - 1 } else { y };
@@ -421,6 +833,41 @@ fn parse_first_commit_date(body: &str) -> Result<Option<String>> {
         .map(str::to_string))
 }
 
+fn parse_gitlab_top_contributor_name(body: &str) -> Result<Option<String>> {
+    let value: serde_json::Value = serde_json::from_str(body).context("invalid JSON")?;
+    let Some(arr) = value.as_array() else {
+        return Ok(None);
+    };
+    let Some(first) = arr.first() else {
+        return Ok(None);
+    };
+    // GitLab contributors are identified by commit author name, not a username.
+    Ok(first
+        .get("name")
+        .and_then(|v| v.as_str())
+        .map(str::to_string))
+}
+
+fn parse_gitlab_first_commit_date(body: &str) -> Result<Option<String>> {
+    let value: serde_json::Value = serde_json::from_str(body).context("invalid JSON")?;
+    let Some(arr) = value.as_array() else {
+        return Ok(None);
+    };
+    // Newest-first ordering on the last page: the chronologically-oldest
+    // record is the LAST element.
+    let Some(last) = arr.last() else {
+        return Ok(None);
+    };
+    // `authored_date` is when the commit was written; fall back to
+    // `committed_date` for forges that omit authored_date.
+    let date = last
+        .get("authored_date")
+        .and_then(|v| v.as_str())
+        .or_else(|| last.get("committed_date").and_then(|v| v.as_str()))
+        .map(str::to_string);
+    Ok(date)
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(
@@ -447,6 +894,8 @@ mod tests {
             bom_ref: None,
         }
     }
+
+    // ---- GitHub URL parsing ----
 
     #[test]
     fn parse_github_repo_extracts_https_url() {
@@ -492,6 +941,106 @@ mod tests {
         assert_eq!(parse_github_repo("https://github.com/onlyowner"), None);
     }
 
+    // ---- GitLab URL parsing ----
+
+    #[test]
+    fn parse_gitlab_repo_extracts_https_url() {
+        assert_eq!(
+            parse_gitlab_repo("https://gitlab.com/foo/bar"),
+            Some(("foo".to_string(), "bar".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_gitlab_repo_strips_dot_git_suffix() {
+        assert_eq!(
+            parse_gitlab_repo("https://gitlab.com/foo/bar.git"),
+            Some(("foo".to_string(), "bar".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_gitlab_repo_handles_trailing_path_and_fragment() {
+        assert_eq!(
+            parse_gitlab_repo("https://gitlab.com/foo/bar/-/tree/main"),
+            Some(("foo".to_string(), "bar".to_string()))
+        );
+        assert_eq!(
+            parse_gitlab_repo("https://gitlab.com/foo/bar#readme"),
+            Some(("foo".to_string(), "bar".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_gitlab_repo_handles_git_plus_and_ssh_forms() {
+        assert_eq!(
+            parse_gitlab_repo("git+https://gitlab.com/foo/bar.git"),
+            Some(("foo".to_string(), "bar".to_string()))
+        );
+        assert_eq!(
+            parse_gitlab_repo("git@gitlab.com:foo/bar.git"),
+            Some(("foo".to_string(), "bar".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_gitlab_repo_returns_none_for_non_gitlab() {
+        assert_eq!(parse_gitlab_repo("https://github.com/foo/bar"), None);
+        assert_eq!(parse_gitlab_repo("https://codeberg.org/foo/bar"), None);
+        assert_eq!(parse_gitlab_repo("https://example.com/foo/bar"), None);
+        assert_eq!(parse_gitlab_repo(""), None);
+        assert_eq!(parse_gitlab_repo("https://gitlab.com/onlyowner"), None);
+    }
+
+    // ---- Codeberg URL parsing ----
+
+    #[test]
+    fn parse_codeberg_repo_extracts_https_url() {
+        assert_eq!(
+            parse_codeberg_repo("https://codeberg.org/foo/bar"),
+            Some(("foo".to_string(), "bar".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_codeberg_repo_strips_dot_git_suffix() {
+        assert_eq!(
+            parse_codeberg_repo("https://codeberg.org/foo/bar.git"),
+            Some(("foo".to_string(), "bar".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_codeberg_repo_handles_trailing_path_and_fragment() {
+        assert_eq!(
+            parse_codeberg_repo("https://codeberg.org/foo/bar/src/branch/main"),
+            Some(("foo".to_string(), "bar".to_string()))
+        );
+        assert_eq!(
+            parse_codeberg_repo("https://codeberg.org/foo/bar#readme"),
+            Some(("foo".to_string(), "bar".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_codeberg_repo_handles_ssh_form() {
+        assert_eq!(
+            parse_codeberg_repo("git@codeberg.org:foo/bar.git"),
+            Some(("foo".to_string(), "bar".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_codeberg_repo_returns_none_for_non_codeberg() {
+        assert_eq!(parse_codeberg_repo("https://github.com/foo/bar"), None);
+        assert_eq!(parse_codeberg_repo("https://gitlab.com/foo/bar"), None);
+        assert_eq!(parse_codeberg_repo("https://example.com/foo/bar"), None);
+        assert_eq!(parse_codeberg_repo(""), None);
+        assert_eq!(parse_codeberg_repo("https://codeberg.org/onlyowner"), None);
+    }
+
+    // ---- Link header parsing ----
+
     #[test]
     fn parse_link_last_page_extracts_page_number() {
         let header = r#"<https://api.github.com/repositories/1/contributors?per_page=1&page=2>; rel="next", <https://api.github.com/repositories/1/contributors?per_page=1&page=42>; rel="last""#;
@@ -509,10 +1058,12 @@ mod tests {
         assert_eq!(parse_link_last_page(None), None);
     }
 
+    // ---- ISO-8601 parsing ----
+
     #[test]
     fn iso8601_round_trips_known_date() {
         // 2024-03-29T00:00:00Z is xz-backdoor-disclosure day. Sanity check the
-        // parser by computing days since unix epoch (1970-01-01 → 19,811 days).
+        // parser by computing days since unix epoch (1970-01-01 -> 19,811 days).
         let secs = iso8601_to_unix_seconds("2024-03-29T00:00:00Z").expect("valid date");
         assert_eq!(secs, 19811 * 86_400);
     }
@@ -538,6 +1089,59 @@ mod tests {
         assert_eq!(iso8601_to_unix_seconds("2024-03-29T00:00:00"), None);
     }
 
+    // ---- normalize_iso8601 ----
+
+    #[test]
+    fn normalize_iso8601_handles_canonical_zulu_form() {
+        assert_eq!(
+            normalize_iso8601("2024-04-15T12:34:56Z"),
+            Some("2024-04-15T12:34:56Z".to_string())
+        );
+    }
+
+    #[test]
+    fn normalize_iso8601_strips_fractional_seconds() {
+        assert_eq!(
+            normalize_iso8601("2024-04-15T12:34:56.123Z"),
+            Some("2024-04-15T12:34:56Z".to_string())
+        );
+        assert_eq!(
+            normalize_iso8601("2024-04-15T12:34:56.000+00:00"),
+            Some("2024-04-15T12:34:56Z".to_string())
+        );
+    }
+
+    #[test]
+    fn normalize_iso8601_rejects_short_input() {
+        assert_eq!(normalize_iso8601(""), None);
+        assert_eq!(normalize_iso8601("2024-04-15"), None);
+        assert_eq!(normalize_iso8601("2024-04-15T12:34"), None);
+    }
+
+    #[test]
+    fn normalize_iso8601_rejects_multibyte_at_slice_point() {
+        // Structural separators pass, but byte 18 is the start of a 3-byte
+        // UTF-8 sequence (the "é" in this hand-crafted nonsense input lands
+        // such that index 19 falls mid-codepoint). Must return None, not panic.
+        let s = "2024-04-15T12:34:5\u{00e9}rest";
+        assert_eq!(normalize_iso8601(s), None);
+    }
+
+    // ---- percent_encode ----
+
+    #[test]
+    fn percent_encode_passes_through_unreserved_chars() {
+        assert_eq!(percent_encode("foo-bar_baz.qux~123"), "foo-bar_baz.qux~123");
+    }
+
+    #[test]
+    fn percent_encode_encodes_slash_and_space() {
+        assert_eq!(percent_encode("owner/repo"), "owner%2Frepo");
+        assert_eq!(percent_encode("Jia Tan"), "Jia%20Tan");
+    }
+
+    // ---- enrich_with smoke tests (GitHub-only path) ----
+
     #[test]
     fn empty_changeset_short_circuits_to_empty_ok() {
         let cs = ChangeSet::default();
@@ -559,6 +1163,8 @@ mod tests {
 
     #[test]
     fn non_github_source_urls_are_silently_skipped() {
+        // enrich_with is GitHub-only; GitLab/Codeberg URLs short-circuit before
+        // any HTTP call, so an unreachable base_url is fine here.
         let cs = ChangeSet {
             added: vec![comp_with_url("foo", Some("https://gitlab.com/foo/bar"))],
             ..Default::default()
@@ -567,6 +1173,40 @@ mod tests {
             .expect("non-github means no HTTP, must succeed");
         assert!(out.is_empty());
     }
+
+    // ---- enrich_with_hosts smoke tests ----
+
+    #[test]
+    fn hosts_empty_changeset_short_circuits() {
+        let cs = ChangeSet::default();
+        let out = enrich_with_hosts(&cs, "http://127.0.0.1:1", Duration::from_millis(50), None)
+            .expect("empty changeset must short-circuit without I/O");
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn hosts_no_source_url_skipped() {
+        let cs = ChangeSet {
+            added: vec![comp_with_url("foo", None)],
+            ..Default::default()
+        };
+        let out = enrich_with_hosts(&cs, "http://127.0.0.1:1", Duration::from_millis(50), None)
+            .expect("no source_url means no HTTP");
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn hosts_unknown_forge_url_skipped() {
+        let cs = ChangeSet {
+            added: vec![comp_with_url("foo", Some("https://example.com/foo/bar"))],
+            ..Default::default()
+        };
+        let out = enrich_with_hosts(&cs, "http://127.0.0.1:1", Duration::from_millis(50), None)
+            .expect("unknown forge means no HTTP");
+        assert!(out.is_empty());
+    }
+
+    // ---- JSON parsers ----
 
     #[test]
     fn parse_top_contributor_returns_login_field() {
@@ -600,5 +1240,45 @@ mod tests {
     #[test]
     fn parse_first_commit_date_handles_empty_array() {
         assert_eq!(parse_first_commit_date("[]").unwrap(), None);
+    }
+
+    #[test]
+    fn parse_gitlab_top_contributor_name_returns_name_field() {
+        let body = r#"[{"name":"Jia Tan","email":"jia.tan@example.com","commits":42}]"#;
+        assert_eq!(
+            parse_gitlab_top_contributor_name(body).unwrap(),
+            Some("Jia Tan".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_gitlab_top_contributor_name_returns_none_for_empty_array() {
+        assert_eq!(parse_gitlab_top_contributor_name("[]").unwrap(), None);
+    }
+
+    #[test]
+    fn parse_gitlab_first_commit_date_takes_last_element_authored_date() {
+        let body = r#"[
+            {"authored_date":"2024-06-01T00:00:00.000+00:00","committed_date":"2024-06-01T00:00:00.000+00:00"},
+            {"authored_date":"2024-01-01T00:00:00.000+00:00","committed_date":"2024-01-01T00:00:00.000+00:00"}
+        ]"#;
+        assert_eq!(
+            parse_gitlab_first_commit_date(body).unwrap(),
+            Some("2024-01-01T00:00:00.000+00:00".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_gitlab_first_commit_date_falls_back_to_committed_date() {
+        let body = r#"[{"committed_date":"2024-03-01T08:00:00.000Z"}]"#;
+        assert_eq!(
+            parse_gitlab_first_commit_date(body).unwrap(),
+            Some("2024-03-01T08:00:00.000Z".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_gitlab_first_commit_date_handles_empty_array() {
+        assert_eq!(parse_gitlab_first_commit_date("[]").unwrap(), None);
     }
 }

--- a/src/render/markdown/maintainer_age.rs
+++ b/src/render/markdown/maintainer_age.rs
@@ -71,6 +71,7 @@ mod tests {
             top_contributor: contributor.to_string(),
             first_commit_at: "2026-04-01T00:00:00Z".to_string(),
             days_old: days,
+            host: crate::enrich::maintainer::Host::Github,
         }
     }
 

--- a/src/render/sarif.rs
+++ b/src/render/sarif.rs
@@ -127,10 +127,10 @@ fn rules() -> Value {
             "bomdrift.young-maintainer",
             "young-maintainer",
             "Top contributor's first commit is recent",
-            "The newly added component is hosted on GitHub and its top \
-             contributor's first commit is younger than 90 days. The xz / \
-             Jia Tan supply-chain-takeover pattern. Always informational \
-             severity (`warning`).",
+            "The newly added component is hosted on GitHub, GitLab, or \
+             Codeberg and its top contributor's first commit is younger than \
+             90 days. The xz / Jia Tan supply-chain-takeover pattern. \
+             Always informational severity (`warning`).",
             "https://metbcy.github.io/bomdrift/enrichers/maintainer-age.html",
         ),
         rule(

--- a/src/run.rs
+++ b/src/run.rs
@@ -203,7 +203,7 @@ fn run_diff(mut args: DiffArgs) -> Result<()> {
     // `--no-maintainer-age` for offline runs. Best-effort: failures warn and
     // continue, mirroring the OSV enricher's contract.
     if !args.no_maintainer_age {
-        match enrich::maintainer::enrich_with(
+        match enrich::maintainer::enrich_with_hosts(
             &cs,
             "https://api.github.com",
             std::time::Duration::from_secs(15),

--- a/src/vex/apply.rs
+++ b/src/vex/apply.rs
@@ -338,6 +338,7 @@ mod tests {
             top_contributor: "alice".into(),
             first_commit_at: "2026-04-26T00:00:00Z".into(),
             days_old: 3,
+            host: crate::enrich::maintainer::Host::Github,
         }];
         let id = crate::vex::synthetic_id::maintainer_age(&e.maintainer_age[0]);
         let idx = VexIndex::build(vec![stmt(&id, purl, VexStatus::NotAffected)]);

--- a/src/vex/synthetic_id.rs
+++ b/src/vex/synthetic_id.rs
@@ -270,6 +270,7 @@ mod tests {
             top_contributor: "alice".into(),
             days_old: 5,
             first_commit_at: "2026-04-26".into(),
+            host: crate::enrich::maintainer::Host::Github,
         };
         let id = synthetic_id::maintainer_age(&f);
         assert_eq!(


### PR DESCRIPTION
Closes #54.

The maintainer-age signal (top contributor's first commit recency, the xz/Jia-Tan pattern) only fired on GitHub before this. A malicious package whose source URL points at gitlab.com or codeberg.org silently slipped past it. This PR wires up multi-host dispatch without touching the GitHub byte-path.

## What's in here

**Type changes (additive only)**
- New `Host` enum: `Github`, `Gitlab`, `Codeberg`
- New `host: Host` field on `MaintainerAgeFinding`. Renderers (markdown, HTML, SARIF) keep working unchanged; only their test fixtures gained the new field.

**Dispatch**
- `enrich_with_hosts` is the new production entry point and what `run.rs` now calls. The old `enrich_with` is kept byte-stable as a GitHub-only path so existing direct callers and tests don't shift behavior.
- Rate-limit tracking is per-host (`[bool; 3]`), so a throttled GitLab can't stop GitHub processing the rest of the SBOM.

**GitLab v4**
- Single `per_page=1` request gets both the top contributor and the `X-Total` contributor count (GitLab returns it on any paginated response). Saves a round-trip vs. doing it the GitHub way.
- One commits call with `?author=` for the first-commit date.
- Honors `GITLAB_TOKEN`. 401/403 = silent skip (private repo / missing token), same as 404.
- If `X-Total` is missing (happens on very large repos), conservatively skip rather than risk a false "1 contributor" claim.

**Codeberg**
- URL parser + `Host::Codeberg` dispatch are wired.
- `lookup_codeberg_repo` is an explicit stub. The Gitea v1 `?author=` commits filter isn't reliably present until Forgejo ~1.20, and Codeberg's deployed API shape needs confirmation. Shipping a clean stub beats shipping a guess that silently produces wrong findings. Follow-up issue territory.

**Utilities**
- `normalize_iso8601` to handle GitLab's `authored_date` formats (fractional seconds, `+00:00` offsets, etc.). Day-granularity is fine against a 90-day threshold; we truncate to `YYYY-MM-DDTHH:MM:SS`. Guards `is_char_boundary(19)` so malformed JSON with a multi-byte codepoint straddling the slice point can't panic the worker.
- `percent_encode` for path-encoded GitLab project IDs.

**Tests**
- 29 new unit tests: URL parsers for both hosts, GitLab JSON parsers, ISO-8601 normalization including the UTF-8 boundary regression, host enum coverage.
- Full suite passes locally, plus `cargo build --all-targets --all-features` with `RUSTFLAGS="-D warnings"`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo fmt --check`.

## Constraints honored

- No new deps. Still `ureq` + `serde_json`. No `tokio`, `reqwest`, `chrono`, `octocrab`.
- GitHub path is byte-stable. Existing `enrich_with` signature preserved.
- `MaintainerAgeFinding` is additive; downstream consumers (markdown/HTML/SARIF/VEX) keep working with one extra field in their test fixtures.

## Follow-ups (not blocking this PR)

- Real Codeberg lookup once the Forgejo `?author=` shape is pinned down.
- GitLab subgroup support (`gitlab.com/group/sub/repo`). Today the parser takes the first two path segments; subgroups silently skip. Easy follow-up since `percent_encode` already handles slashes.
- Cross-linking with `maintainer_set_changed` (the other "maintainer noise" enricher) for higher-confidence joint findings.
