### PR TITLE
test(plugin): assert protocol_version: 1 reaches the wire

### DIFF
--- a/docs/src/plugins.md
+++ b/docs/src/plugins.md
@@ -261,9 +261,10 @@ stable in v0.9.6**:
 - The TOML manifest schema may grow new optional fields; existing
   fields stay.
 
-If the protocol needs a breaking change for v1.0, a deprecation
-window with a `protocol_version` envelope field will land at least
-one minor release before the break.
+If the protocol needs a breaking change for v1.0, every plugin
+invocation already carries `protocol_version: 1` on the stdin
+envelope, so a future bomdrift release can detect old plugins and
+keep them working through a deprecation window.
 
 ## CI integration
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -508,6 +508,58 @@ invoke_on = ["removed"]
 
     #[cfg(unix)]
     #[test]
+    fn plugin_stdin_envelope_includes_protocol_version_1() {
+        // Regression guard: docs/src/plugins.md and the module preamble
+        // both promise plugins see `protocol_version: 1` on the wire so
+        // future bomdrift releases can detect old plugins. We have the
+        // constant (`PROTOCOL_VERSION`) and we serialize it into
+        // `PluginInput`, but nothing previously asserted it actually
+        // reaches the plugin's stdin. This test captures real stdin to a
+        // sibling file and greps it.
+        let dir = unique_dir("envelope");
+        std::fs::create_dir_all(&dir).unwrap();
+        let stdin_capture = dir.join("stdin.json");
+        let script_body = format!(
+            "#!/bin/sh\ncat > {capture}\necho '{{\"findings\":[]}}'\n",
+            capture = stdin_capture.display(),
+        );
+        let exec = write_script(&dir, "capture.sh", &script_body);
+        let manifest = PluginManifest {
+            name: "envelope".into(),
+            description: None,
+            exec,
+            timeout_ms: 5000,
+            invoke_on: vec![InvokeEvent::Added],
+            manifest_path: dir.clone(),
+        };
+        let cs = ChangeSet {
+            added: vec![comp("left-pad")],
+            ..Default::default()
+        };
+        let _ = run_plugins(std::slice::from_ref(&manifest), &cs);
+
+        let captured = std::fs::read_to_string(&stdin_capture)
+            .expect("plugin script should have captured stdin to the sibling file");
+        let parsed: serde_json::Value =
+            serde_json::from_str(&captured).expect("plugin stdin must be a JSON object");
+        assert_eq!(
+            parsed.get("protocol_version").and_then(|v| v.as_u64()),
+            Some(1),
+            "plugin stdin must carry `protocol_version: 1`; got envelope:\n{captured}"
+        );
+        // The constant and the wire value must agree — if anyone bumps
+        // PROTOCOL_VERSION they have to update the docs + this test
+        // together.
+        assert_eq!(
+            parsed.get("protocol_version").and_then(|v| v.as_u64()),
+            Some(u64::from(PROTOCOL_VERSION)),
+            "wire `protocol_version` must equal the PROTOCOL_VERSION constant"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn plugin_invocation_returns_findings() {
         let dir = unique_dir("happy");
         let exec = write_script(


### PR DESCRIPTION
## What

Adds a regression test that asserts `protocol_version: 1` actually shows up on the plugin stdin envelope, and refreshes the stale stability-promise prose in `docs/src/plugins.md`.

## Why

The module preamble (`src/plugin.rs`) and `docs/src/plugins.md` both promise plugins see a `protocol_version` field so future bomdrift releases can detect old plugins and stay backward-compatible. We have the `PROTOCOL_VERSION` constant and we serialize it into `PluginInput`, but nothing previously locked that contract down: a stray refactor to `PluginInput` could silently drop the field without any test failing. The docs were also still framing the field as future work, even though it's been on the wire since v0.9.6.

## How

- New `plugin_stdin_envelope_includes_protocol_version_1` test points a real plugin at a capture script, reads the stdin back, and asserts:
  - `protocol_version == 1` on the wire
  - the wire value equals the `PROTOCOL_VERSION` constant, so any future bump has to update the docs and this test together
- Docs prose updated to describe the current state (`protocol_version: 1` is already on every invocation) instead of promising it as a future addition

No behavior change. Pure test + docs.

## Verification

```
cargo fmt --all --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all-features --lib plugin_stdin_envelope_includes_protocol_version_1
```

All green locally.
