### PR TITLE
feat(ci-templates): Bitbucket + Azure parity with the GitHub Action (closes #32)

### DIFF
--- a/docs/src/azure-devops.md
+++ b/docs/src/azure-devops.md
@@ -79,6 +79,88 @@ The full threat model and deployment guide live in
 The same logic ports to Vercel / Netlify / AWS Lambda — see
 [`vercel-equivalent.md`](https://github.com/Metbcy/bomdrift/blob/main/examples/azure-devops/comment-bridge/vercel-equivalent.md).
 
+## Input reference
+
+The example pipeline exposes optional template parameters that are
+forwarded to `bomdrift diff` as CLI flags. Override them at queue
+time (Run pipeline, Variables / Parameters dialog) or pin defaults
+by editing the `parameters:` block in the YAML; you can also wire a
+pipeline variable through a parameter for org-wide defaults. Unset
+parameters contribute zero CLI arguments, so the default invocation
+matches the bare v0.9 template exactly.
+
+This mirrors the [GitHub Action input
+surface](https://github.com/Metbcy/bomdrift/blob/main/action.yml);
+descriptions are abridged from `action.yml`.
+
+### VEX
+
+- `vex` (newline-separated paths to OpenVEX documents), each
+  forwarded as a repeated `--vex <path>`.
+- `emit_vex` (path), write a fresh OpenVEX document derived from
+  the diff (`--emit-vex <path>`).
+- `vex_author`, author identity recorded on emitted VEX
+  (`--vex-author <author>`).
+- `vex_default_justification`, default OpenVEX `not_affected`
+  justification (`--vex-default-justification <id>`).
+
+### License policy
+
+- `allow_licenses`, comma-separated SPDX expressions to allow
+  (`--allow-licenses`).
+- `deny_licenses`, comma-separated SPDX expressions to deny
+  (`--deny-licenses`).
+- `allow_exception`, SPDX exception identifiers to allow inside
+  `WITH` clauses (`--allow-exception`).
+- `deny_exception`, SPDX exception identifiers to deny
+  (`--deny-exception`).
+- `allow_ambiguous_licenses` (boolean), set to `true` to treat
+  unresolvable expressions as allowed
+  (`--allow-ambiguous-licenses`).
+
+### Enrichment toggles
+
+- `no_epss` (boolean), set to `true` to disable EPSS enrichment
+  (`--no-epss`).
+- `no_kev` (boolean), set to `true` to disable CISA KEV enrichment
+  (`--no-kev`).
+- `no_registry` (boolean), set to `true` to disable registry and
+  maintainer enrichment (`--no-registry`).
+- `fail_on_epss`, exit 2 when any new advisory has an EPSS score
+  at or above this threshold (0.0 to 1.0,
+  `--fail-on-epss <FLOAT>`).
+
+### Calibration
+
+- `recently_published_days`, window (days) for the
+  recently-published maintainer-age signal.
+- `typosquat_similarity_threshold`, Damerau-Levenshtein similarity
+  threshold (0.0 to 1.0).
+- `young_maintainer_days`, age threshold (days) below which a
+  maintainer is flagged as young.
+- `cache_ttl_hours`, TTL (hours) for the on-disk enrichment cache.
+- `multi_major_delta`, major-version delta at or above which a
+  version jump is flagged as multi-major (default 2, minimum 1).
+
+### Attestation
+
+- `before_attestation`, OCI reference for the cosign attestation
+  covering the before SBOM (`--before-attestation <oci-ref>`).
+- `after_attestation`, OCI reference for the after SBOM
+  (`--after-attestation <oci-ref>`).
+- `cosign_identity`, regex matched against the cosign certificate
+  identity (`--cosign-identity <regex>`).
+- `cosign_issuer`, OIDC issuer URL used for keyless cosign
+  verification (`--cosign-issuer <url>`).
+- `require_attestation` (boolean), set to `true` to fail the diff
+  when either side is missing a verified attestation
+  (`--require-attestation`).
+
+### Plugins
+
+- `plugin` (newline-separated paths to plugin manifests, i.e.
+  `plugin.toml`), each forwarded as a repeated `--plugin <path>`.
+
 ## Troubleshooting
 
 See [`examples/azure-devops/README.md`](https://github.com/Metbcy/bomdrift/blob/main/examples/azure-devops/README.md).

--- a/docs/src/bitbucket.md
+++ b/docs/src/bitbucket.md
@@ -82,6 +82,90 @@ The full threat model and deployment guide live in
 The same logic ports to Vercel / Netlify / AWS Lambda — see
 [`vercel-equivalent.md`](https://github.com/Metbcy/bomdrift/blob/main/examples/bitbucket-pipelines/comment-bridge/vercel-equivalent.md).
 
+## Input reference
+
+The example pipeline reads optional `BOMDRIFT_*` repository (or
+workspace) variables and forwards each as a `bomdrift diff` flag.
+Set them under **Repository settings, Repository variables** (or
+**Workspace variables** for organization-wide defaults). Unset
+variables contribute zero CLI arguments, so the default invocation
+matches the bare v0.9 template exactly.
+
+This mirrors the [GitHub Action input
+surface](https://github.com/Metbcy/bomdrift/blob/main/action.yml);
+descriptions are abridged from `action.yml`.
+
+### VEX
+
+- `BOMDRIFT_VEX` (newline-separated paths to OpenVEX documents),
+  each forwarded as a repeated `--vex <path>`.
+- `BOMDRIFT_EMIT_VEX` (path), write a fresh OpenVEX document
+  derived from the diff (`--emit-vex <path>`).
+- `BOMDRIFT_VEX_AUTHOR`, author identity recorded on emitted VEX
+  (`--vex-author <author>`).
+- `BOMDRIFT_VEX_DEFAULT_JUSTIFICATION`, default OpenVEX
+  `not_affected` justification (`--vex-default-justification <id>`).
+
+### License policy
+
+- `BOMDRIFT_ALLOW_LICENSES`, comma-separated SPDX expressions to
+  allow (`--allow-licenses`).
+- `BOMDRIFT_DENY_LICENSES`, comma-separated SPDX expressions to
+  deny (`--deny-licenses`).
+- `BOMDRIFT_ALLOW_EXCEPTION`, SPDX exception identifiers to allow
+  inside `WITH` clauses (`--allow-exception`).
+- `BOMDRIFT_DENY_EXCEPTION`, SPDX exception identifiers to deny
+  (`--deny-exception`).
+- `BOMDRIFT_ALLOW_AMBIGUOUS_LICENSES`, set to `true` to treat
+  unresolvable expressions as allowed (`--allow-ambiguous-licenses`).
+
+### Enrichment toggles
+
+- `BOMDRIFT_NO_EPSS`, set to `true` to disable EPSS enrichment
+  (`--no-epss`).
+- `BOMDRIFT_NO_KEV`, set to `true` to disable CISA KEV enrichment
+  (`--no-kev`).
+- `BOMDRIFT_NO_REGISTRY`, set to `true` to disable registry and
+  maintainer enrichment (`--no-registry`).
+- `BOMDRIFT_FAIL_ON_EPSS`, exit 2 when any new advisory has an
+  EPSS score at or above this threshold (0.0 to 1.0,
+  `--fail-on-epss <FLOAT>`).
+
+### Calibration
+
+- `BOMDRIFT_RECENTLY_PUBLISHED_DAYS`, window (days) for the
+  recently-published maintainer-age signal.
+- `BOMDRIFT_TYPOSQUAT_SIMILARITY_THRESHOLD`,
+  Damerau-Levenshtein similarity threshold (0.0 to 1.0).
+- `BOMDRIFT_YOUNG_MAINTAINER_DAYS`, age threshold (days) below
+  which a maintainer is flagged as young.
+- `BOMDRIFT_CACHE_TTL_HOURS`, TTL (hours) for the on-disk
+  enrichment cache.
+- `BOMDRIFT_MULTI_MAJOR_DELTA`, major-version delta at or above
+  which a version jump is flagged as multi-major (default 2,
+  minimum 1).
+
+### Attestation
+
+- `BOMDRIFT_BEFORE_ATTESTATION`, OCI reference for the cosign
+  attestation covering the before SBOM
+  (`--before-attestation <oci-ref>`).
+- `BOMDRIFT_AFTER_ATTESTATION`, OCI reference for the after SBOM
+  (`--after-attestation <oci-ref>`).
+- `BOMDRIFT_COSIGN_IDENTITY`, regex matched against the cosign
+  certificate identity (`--cosign-identity <regex>`).
+- `BOMDRIFT_COSIGN_ISSUER`, OIDC issuer URL used for keyless
+  cosign verification (`--cosign-issuer <url>`).
+- `BOMDRIFT_REQUIRE_ATTESTATION`, set to `true` to fail the diff
+  when either side is missing a verified attestation
+  (`--require-attestation`).
+
+### Plugins
+
+- `BOMDRIFT_PLUGIN` (newline-separated paths to plugin manifests,
+  i.e. `plugin.toml`), each forwarded as a repeated
+  `--plugin <path>`.
+
 ## Troubleshooting
 
 See [`examples/bitbucket-pipelines/README.md`](https://github.com/Metbcy/bomdrift/blob/main/examples/bitbucket-pipelines/README.md).

--- a/examples/azure-devops/azure-pipelines.yml
+++ b/examples/azure-devops/azure-pipelines.yml
@@ -17,6 +17,84 @@ parameters:
   - name: BOMDRIFT_NOTE_BODY
     type: string
     default: ""
+  # VEX
+  - name: vex
+    type: string
+    default: ""
+  - name: emit_vex
+    type: string
+    default: ""
+  - name: vex_author
+    type: string
+    default: ""
+  - name: vex_default_justification
+    type: string
+    default: ""
+  # License policy
+  - name: allow_licenses
+    type: string
+    default: ""
+  - name: deny_licenses
+    type: string
+    default: ""
+  - name: allow_exception
+    type: string
+    default: ""
+  - name: deny_exception
+    type: string
+    default: ""
+  - name: allow_ambiguous_licenses
+    type: boolean
+    default: false
+  # Enrichment toggles
+  - name: no_epss
+    type: boolean
+    default: false
+  - name: no_kev
+    type: boolean
+    default: false
+  - name: no_registry
+    type: boolean
+    default: false
+  - name: fail_on_epss
+    type: string
+    default: ""
+  # Calibration
+  - name: recently_published_days
+    type: string
+    default: ""
+  - name: typosquat_similarity_threshold
+    type: string
+    default: ""
+  - name: young_maintainer_days
+    type: string
+    default: ""
+  - name: cache_ttl_hours
+    type: string
+    default: ""
+  - name: multi_major_delta
+    type: string
+    default: ""
+  # Attestation
+  - name: before_attestation
+    type: string
+    default: ""
+  - name: after_attestation
+    type: string
+    default: ""
+  - name: cosign_identity
+    type: string
+    default: ""
+  - name: cosign_issuer
+    type: string
+    default: ""
+  - name: require_attestation
+    type: boolean
+    default: false
+  # Plugins
+  - name: plugin
+    type: string
+    default: ""
 
 pool:
   vmImage: ubuntu-latest
@@ -46,10 +124,84 @@ stages:
               git worktree add ../before "origin/$(System.PullRequest.TargetBranch)"
               syft dir:../before -o cyclonedx-json=before.cdx.json
               syft dir:. -o cyclonedx-json=after.cdx.json
+              # Build optional --flag args from the pipeline parameters
+              # exposed via the env: block below. Empty / false values
+              # contribute zero args, so users who set none of these get
+              # the byte-identical v0.9 invocation.
+              args=()
+              add_value() {
+                if [ -n "$2" ]; then args+=("$1" "$2"); fi
+              }
+              add_bool() {
+                if [ "$2" = "true" ]; then args+=("$1"); fi
+              }
+              add_list() {
+                if [ -z "$2" ]; then return 0; fi
+                while IFS= read -r _line; do
+                  if [ -n "$_line" ]; then args+=("$1" "$_line"); fi
+                done <<EOF
+              $2
+              EOF
+              }
+              # VEX
+              add_list  --vex "${BOMDRIFT_VEX:-}"
+              add_value --emit-vex "${BOMDRIFT_EMIT_VEX:-}"
+              add_value --vex-author "${BOMDRIFT_VEX_AUTHOR:-}"
+              add_value --vex-default-justification "${BOMDRIFT_VEX_DEFAULT_JUSTIFICATION:-}"
+              # License policy
+              add_value --allow-licenses "${BOMDRIFT_ALLOW_LICENSES:-}"
+              add_value --deny-licenses "${BOMDRIFT_DENY_LICENSES:-}"
+              add_value --allow-exception "${BOMDRIFT_ALLOW_EXCEPTION:-}"
+              add_value --deny-exception "${BOMDRIFT_DENY_EXCEPTION:-}"
+              add_bool  --allow-ambiguous-licenses "${BOMDRIFT_ALLOW_AMBIGUOUS_LICENSES:-}"
+              # Enrichment toggles
+              add_bool  --no-epss "${BOMDRIFT_NO_EPSS:-}"
+              add_bool  --no-kev "${BOMDRIFT_NO_KEV:-}"
+              add_bool  --no-registry "${BOMDRIFT_NO_REGISTRY:-}"
+              add_value --fail-on-epss "${BOMDRIFT_FAIL_ON_EPSS:-}"
+              # Calibration
+              add_value --recently-published-days "${BOMDRIFT_RECENTLY_PUBLISHED_DAYS:-}"
+              add_value --typosquat-similarity-threshold "${BOMDRIFT_TYPOSQUAT_SIMILARITY_THRESHOLD:-}"
+              add_value --young-maintainer-days "${BOMDRIFT_YOUNG_MAINTAINER_DAYS:-}"
+              add_value --cache-ttl-hours "${BOMDRIFT_CACHE_TTL_HOURS:-}"
+              add_value --multi-major-delta "${BOMDRIFT_MULTI_MAJOR_DELTA:-}"
+              # Attestation
+              add_value --before-attestation "${BOMDRIFT_BEFORE_ATTESTATION:-}"
+              add_value --after-attestation "${BOMDRIFT_AFTER_ATTESTATION:-}"
+              add_value --cosign-identity "${BOMDRIFT_COSIGN_IDENTITY:-}"
+              add_value --cosign-issuer "${BOMDRIFT_COSIGN_ISSUER:-}"
+              add_bool  --require-attestation "${BOMDRIFT_REQUIRE_ATTESTATION:-}"
+              # Plugins
+              add_list --plugin "${BOMDRIFT_PLUGIN:-}"
               bomdrift diff before.cdx.json after.cdx.json \
-                --output markdown --platform azure-devops > comment.md
+                --output markdown --platform azure-devops "${args[@]}" > comment.md
               printf '\n<!-- bomdrift:diff -->\n' >> comment.md
             displayName: bomdrift diff
+            env:
+              BOMDRIFT_VEX: ${{ parameters.vex }}
+              BOMDRIFT_EMIT_VEX: ${{ parameters.emit_vex }}
+              BOMDRIFT_VEX_AUTHOR: ${{ parameters.vex_author }}
+              BOMDRIFT_VEX_DEFAULT_JUSTIFICATION: ${{ parameters.vex_default_justification }}
+              BOMDRIFT_ALLOW_LICENSES: ${{ parameters.allow_licenses }}
+              BOMDRIFT_DENY_LICENSES: ${{ parameters.deny_licenses }}
+              BOMDRIFT_ALLOW_EXCEPTION: ${{ parameters.allow_exception }}
+              BOMDRIFT_DENY_EXCEPTION: ${{ parameters.deny_exception }}
+              BOMDRIFT_ALLOW_AMBIGUOUS_LICENSES: ${{ parameters.allow_ambiguous_licenses }}
+              BOMDRIFT_NO_EPSS: ${{ parameters.no_epss }}
+              BOMDRIFT_NO_KEV: ${{ parameters.no_kev }}
+              BOMDRIFT_NO_REGISTRY: ${{ parameters.no_registry }}
+              BOMDRIFT_FAIL_ON_EPSS: ${{ parameters.fail_on_epss }}
+              BOMDRIFT_RECENTLY_PUBLISHED_DAYS: ${{ parameters.recently_published_days }}
+              BOMDRIFT_TYPOSQUAT_SIMILARITY_THRESHOLD: ${{ parameters.typosquat_similarity_threshold }}
+              BOMDRIFT_YOUNG_MAINTAINER_DAYS: ${{ parameters.young_maintainer_days }}
+              BOMDRIFT_CACHE_TTL_HOURS: ${{ parameters.cache_ttl_hours }}
+              BOMDRIFT_MULTI_MAJOR_DELTA: ${{ parameters.multi_major_delta }}
+              BOMDRIFT_BEFORE_ATTESTATION: ${{ parameters.before_attestation }}
+              BOMDRIFT_AFTER_ATTESTATION: ${{ parameters.after_attestation }}
+              BOMDRIFT_COSIGN_IDENTITY: ${{ parameters.cosign_identity }}
+              BOMDRIFT_COSIGN_ISSUER: ${{ parameters.cosign_issuer }}
+              BOMDRIFT_REQUIRE_ATTESTATION: ${{ parameters.require_attestation }}
+              BOMDRIFT_PLUGIN: ${{ parameters.plugin }}
 
           - script: |
               set -euo pipefail

--- a/examples/bitbucket-pipelines/bitbucket-pipelines.yml
+++ b/examples/bitbucket-pipelines/bitbucket-pipelines.yml
@@ -2,6 +2,46 @@
 #
 # Required variables:
 #   - BOMDRIFT_API_TOKEN: App Password with `pullrequest:write` scope.
+#
+# Optional repository / workspace variables (all default to empty / off,
+# in which case the diff invocation stays byte-identical to the v0.9
+# baseline). Each maps to a `bomdrift diff` CLI flag of the same name.
+#
+#   VEX:
+#     BOMDRIFT_VEX                          (newline-separated paths, repeated --vex)
+#     BOMDRIFT_EMIT_VEX                     (path)
+#     BOMDRIFT_VEX_AUTHOR                   (string)
+#     BOMDRIFT_VEX_DEFAULT_JUSTIFICATION    (string)
+#
+#   License policy:
+#     BOMDRIFT_ALLOW_LICENSES               (SPDX list)
+#     BOMDRIFT_DENY_LICENSES                (SPDX list)
+#     BOMDRIFT_ALLOW_EXCEPTION              (SPDX exception list)
+#     BOMDRIFT_DENY_EXCEPTION               (SPDX exception list)
+#     BOMDRIFT_ALLOW_AMBIGUOUS_LICENSES     ('true' to enable flag)
+#
+#   Enrichment toggles:
+#     BOMDRIFT_NO_EPSS                      ('true' to disable EPSS)
+#     BOMDRIFT_NO_KEV                       ('true' to disable KEV)
+#     BOMDRIFT_NO_REGISTRY                  ('true' to disable registry)
+#     BOMDRIFT_FAIL_ON_EPSS                 (float 0.0 to 1.0)
+#
+#   Calibration:
+#     BOMDRIFT_RECENTLY_PUBLISHED_DAYS      (integer)
+#     BOMDRIFT_TYPOSQUAT_SIMILARITY_THRESHOLD (float)
+#     BOMDRIFT_YOUNG_MAINTAINER_DAYS        (integer)
+#     BOMDRIFT_CACHE_TTL_HOURS              (integer)
+#     BOMDRIFT_MULTI_MAJOR_DELTA            (integer)
+#
+#   Attestation:
+#     BOMDRIFT_BEFORE_ATTESTATION           (OCI ref)
+#     BOMDRIFT_AFTER_ATTESTATION            (OCI ref)
+#     BOMDRIFT_COSIGN_IDENTITY              (regex)
+#     BOMDRIFT_COSIGN_ISSUER                (URL)
+#     BOMDRIFT_REQUIRE_ATTESTATION          ('true' to require)
+#
+#   Plugins:
+#     BOMDRIFT_PLUGIN                       (newline-separated paths, repeated --plugin)
 
 image: rust:1.88
 
@@ -20,7 +60,60 @@ definitions:
           - git worktree add ../before "origin/$BITBUCKET_PR_DESTINATION_BRANCH"
           - syft dir:../before -o cyclonedx-json=before.cdx.json
           - syft dir:. -o cyclonedx-json=after.cdx.json
-          - bomdrift diff before.cdx.json after.cdx.json --output markdown --platform bitbucket > comment.md
+          - |
+            # Build optional --flag args from BOMDRIFT_* repository variables.
+            # Empty / unset vars contribute zero args, so the default invocation
+            # stays byte-identical for users who set none of these.
+            args=()
+            add_value() {
+              # add_value <flag> <value>; emits nothing if value is empty.
+              if [ -n "$2" ]; then args+=("$1" "$2"); fi
+            }
+            add_bool() {
+              # add_bool <flag> <value>; emits flag only when value == 'true'.
+              if [ "$2" = "true" ]; then args+=("$1"); fi
+            }
+            add_list() {
+              # add_list <flag> <newline-separated-values>; emits a repeated
+              # <flag> <value> pair for each non-empty line.
+              if [ -z "$2" ]; then return 0; fi
+              while IFS= read -r _line; do
+                if [ -n "$_line" ]; then args+=("$1" "$_line"); fi
+              done <<EOF
+            $2
+            EOF
+            }
+            # VEX
+            add_list --vex "${BOMDRIFT_VEX:-}"
+            add_value --emit-vex "${BOMDRIFT_EMIT_VEX:-}"
+            add_value --vex-author "${BOMDRIFT_VEX_AUTHOR:-}"
+            add_value --vex-default-justification "${BOMDRIFT_VEX_DEFAULT_JUSTIFICATION:-}"
+            # License policy
+            add_value --allow-licenses "${BOMDRIFT_ALLOW_LICENSES:-}"
+            add_value --deny-licenses "${BOMDRIFT_DENY_LICENSES:-}"
+            add_value --allow-exception "${BOMDRIFT_ALLOW_EXCEPTION:-}"
+            add_value --deny-exception "${BOMDRIFT_DENY_EXCEPTION:-}"
+            add_bool  --allow-ambiguous-licenses "${BOMDRIFT_ALLOW_AMBIGUOUS_LICENSES:-}"
+            # Enrichment toggles
+            add_bool  --no-epss "${BOMDRIFT_NO_EPSS:-}"
+            add_bool  --no-kev "${BOMDRIFT_NO_KEV:-}"
+            add_bool  --no-registry "${BOMDRIFT_NO_REGISTRY:-}"
+            add_value --fail-on-epss "${BOMDRIFT_FAIL_ON_EPSS:-}"
+            # Calibration
+            add_value --recently-published-days "${BOMDRIFT_RECENTLY_PUBLISHED_DAYS:-}"
+            add_value --typosquat-similarity-threshold "${BOMDRIFT_TYPOSQUAT_SIMILARITY_THRESHOLD:-}"
+            add_value --young-maintainer-days "${BOMDRIFT_YOUNG_MAINTAINER_DAYS:-}"
+            add_value --cache-ttl-hours "${BOMDRIFT_CACHE_TTL_HOURS:-}"
+            add_value --multi-major-delta "${BOMDRIFT_MULTI_MAJOR_DELTA:-}"
+            # Attestation
+            add_value --before-attestation "${BOMDRIFT_BEFORE_ATTESTATION:-}"
+            add_value --after-attestation "${BOMDRIFT_AFTER_ATTESTATION:-}"
+            add_value --cosign-identity "${BOMDRIFT_COSIGN_IDENTITY:-}"
+            add_value --cosign-issuer "${BOMDRIFT_COSIGN_ISSUER:-}"
+            add_bool  --require-attestation "${BOMDRIFT_REQUIRE_ATTESTATION:-}"
+            # Plugins
+            add_list --plugin "${BOMDRIFT_PLUGIN:-}"
+            bomdrift diff before.cdx.json after.cdx.json --output markdown --platform bitbucket "${args[@]}" > comment.md
           - echo "" >> comment.md
           - echo "<!-- bomdrift:diff -->" >> comment.md
           - REPO="$BITBUCKET_REPO_FULL_NAME"


### PR DESCRIPTION
Closes #32.

Brings the Bitbucket Pipelines and Azure DevOps templates up to the v0.9.7 GitHub Action input surface, so non-GitHub callers can configure the same `bomdrift diff` knobs the action exposes.

## What's added (on both platforms)

**VEX:** `vex` (list), `emit-vex`, `vex-author`, `vex-default-justification`
**License policy:** `allow-licenses`, `deny-licenses`, `allow-exception`, `deny-exception`, `allow-ambiguous-licenses`
**Enrichment toggles:** `no-epss`, `no-kev`, `no-registry`, `fail-on-epss`
**Calibration:** `recently-published-days`, `typosquat-similarity-threshold`, `young-maintainer-days`, `cache-ttl-hours`, `multi-major-delta`
**Attestation:** `before-attestation`, `after-attestation`, `cosign-identity`, `cosign-issuer`, `require-attestation`
**Plugins:** `plugin` (list)

## Implementation

Both templates use the same pattern: a small bash helper block defines `add_value` / `add_bool` / `add_list`, then builds an `args=()` array from `BOMDRIFT_*` env vars and appends `"${args[@]}"` after the existing `--output markdown --platform <name>` flags. Unset / empty inputs contribute zero CLI args, so the default invocation is byte-identical for users who don't set any of the new variables.

- **Bitbucket** reads inputs from repository variables (prefix `BOMDRIFT_*`).
- **Azure** declares them as `parameters:` (snake_case because `${{ parameters.x-y }}` won't expand cleanly with hyphens) and maps them through the `env:` block on the diff step to the same `BOMDRIFT_*` names.

## Verification

- Both YAML files parse with `python3 -c "import yaml; yaml.safe_load(...)"`.
- Inline bash passes `bash -n`.
- Empty-input invocation reduces to the pre-PR command shape (confirmed by inspection of the args-building helpers — `add_value`/`add_bool`/`add_list` all short-circuit on empty/non-`true` values).
- Docs sections in `bitbucket.md` and `azure-devops.md` mirror the action.yml descriptions verbatim where the brief allowed, abridged where length required.

## Notes for maintainer

Repo policy: `main` requires verified signatures. This branch is unsigned; "Merge" or "Squash" via the GitHub UI auto-signs.

The Azure JSON schema doesn't model boolean parameter defaults so the editor LSP will flag a warning on the `default: false` lines — the syntax is still valid Azure Pipelines YAML (verified against the public docs). Left as-is.
